### PR TITLE
Bump alembic and sqlalchemy for Python 3.13 compatibility.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ dependencies = [
     "typing-extensions==4.14.1",        # (indirect dependency)
 
     # These also move as a set
-    "alembic==1.15.2",                  # mit
-    "sqlalchemy==2.0.29",               # mit
+    "alembic==1.17.2",                  # mit
+    "sqlalchemy==2.0.36",               # mit
     "mysqlclient==2.1.1",               # gpl
 
     # Optional dependancies, depending on what clouds you want to provide access to


### PR DESCRIPTION
SQLAlchemy 2.0.29 is incompatible with Python 3.13 due to new class attributes (__static_attributes__ and __firstlineno__) that Python 3.13 adds to classes. SQLAlchemy's TypingOnly metaclass fails with an AssertionError when it encounters these attributes.

This was fixed in SQLAlchemy 2.0.30. Bump to 2.0.36 (current latest) and alembic to 1.17.2 to match.

Prompt: Kolla-Ansible is failing to deploy OpenStack with an ansible error. What is the issue?


Assisted-By: Claude Code