### PR TITLE
Add comprehensive SPICE protocol documentation.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,15 @@ Protocol packets are in `kerbside/spiceprotocol/packets/`:
 - Each packet type has a parser class
 - Parsers return consumed byte count (0 if incomplete)
 - Use `struct.unpack_from()` for binary parsing
-- Reference: https://www.spice-space.org/spice-protocol.html
+
+See the protocol documentation in `docs/` for detailed information:
+- `docs/protocol-overview.md` - SPICE protocol fundamentals
+- `docs/spice-link-protocol.md` - Connection handshake and authentication
+- `docs/channel-protocols.md` - Per-channel message formats
+- `docs/usb-redirection.md` - USB device redirection protocol
+- `docs/proxy-architecture.md` - Kerbside proxy internals
+
+External reference: https://www.spice-space.org/spice-protocol.html
 
 ## Testing
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -261,4 +261,14 @@ etc/                   # Configuration examples
 tools/                 # Utility scripts
 testclient/            # Ryll test client
 loadtests/             # Load testing tools
+docs/                  # Protocol documentation
 ```
+
+## Related Documentation
+
+For detailed SPICE protocol documentation, see the [docs/](docs/) directory:
+
+- [Protocol Overview](docs/protocol-overview.md) - SPICE protocol fundamentals
+- [Channel Protocols](docs/channel-protocols.md) - Per-channel message formats
+- [Capabilities](docs/capabilities.md) - Feature negotiation
+- [Proxy Architecture](docs/proxy-architecture.md) - Internal proxy design details

--- a/README.md
+++ b/README.md
@@ -12,6 +12,34 @@ those at the moment because there are patches to add deployment support for
 Kerbside to Kolla-Ansible, whereas there is no deployment support for Shaken
 Fist just yet.
 
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) - High-level system architecture
+- [AGENTS.md](AGENTS.md) - AI agent guidelines for working on this codebase
+- [docs/](docs/) - Full documentation:
+  - [Documentation Index](docs/index.md) - Full documentation index with
+    overview and introduction
+  - Operator documentation:
+    - [Configuration](docs/configuration.md) - Configuration reference
+    - [Console Sources](docs/console-sources.md) - Configuring sources.yaml
+  - Protocol documentation:
+    - [Protocol Overview](docs/protocol-overview.md) - SPICE protocol
+      fundamentals
+    - [Link Protocol](docs/spice-link-protocol.md) - Connection handshake and
+      authentication
+    - [Channel Protocols](docs/channel-protocols.md) - Per-channel message
+      formats (main, display, inputs, cursor, audio, smartcard)
+    - [Keyboard Scancodes](docs/scancodes.md) - IBM PC XT scancode reference
+      for the inputs channel
+    - [Compression Protocols](docs/compression-protocols.md) - LZ and GLZ
+      image compression formats
+    - [Capabilities](docs/capabilities.md) - Channel capability negotiation
+    - [USB Redirection](docs/usb-redirection.md) - USB device redirection
+      protocol
+    - [VD Agent Protocol](docs/vd-agent-protocol.md) - Guest agent for
+      clipboard, file transfer, and display configuration
+    - [Proxy Architecture](docs/proxy-architecture.md) - Internal proxy design
+
 ## Bootstrap CSS
 
 Kerbside uses bootstrap CSS for styling. This was constructed by downloading

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,175 @@
+# SPICE Capabilities
+
+This document describes the capability negotiation system used by the SPICE
+protocol. Capabilities are exchanged during the link handshake to determine
+which features both client and server support.
+
+## Capability Negotiation
+
+During the SPICE link handshake, both client and server exchange capability
+bitmaps. A feature is only enabled if both sides advertise support for it.
+Capabilities are organized into:
+
+- **Common capabilities**: Apply to all channel types
+- **Channel-specific capabilities**: Apply only to specific channels
+
+## Common Capabilities
+
+These capabilities apply to all SPICE channels.
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | AuthSelection | Client can select authentication mechanism |
+| 1 | AuthSpice | SPICE ticket-based authentication supported |
+| 2 | AuthSASL | SASL authentication supported |
+| 3 | MiniHeader | Use compact 6-byte message headers instead of 16-byte |
+
+### Mini Header Format
+
+When both sides support `MiniHeader`, messages use a compact format:
+
+**Standard Header (16 bytes):**
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       8     uint64  serial
+8       2     uint16  type
+10      4     uint32  size
+14      4     uint32  sub_list
+```
+
+**Mini Header (6 bytes):**
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  type
+2       4     uint32  size
+```
+
+## Main Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | SemiSeamlessMigrate | Semi-seamless VM migration support |
+| 1 | NameAndUuid | Server sends VM name and UUID to client |
+| 2 | AgentConnectedTokens | Token-based agent connection tracking |
+| 3 | SeamlessMigrate | Seamless VM migration support |
+
+## Display Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | SizedStream | Stream data messages include dimensions |
+| 1 | MonitorsConfig | Multi-monitor configuration support |
+| 2 | Composite | Composite drawing operations supported |
+| 3 | A8Surface | 8-bit alpha-only surfaces supported |
+| 4 | StreamReport | Stream quality/performance reporting |
+| 5 | LZ4Compression | LZ4 image compression supported |
+| 6 | PrefCompression | Client compression preference |
+| 7 | GLScanout | GPU acceleration via DMA-buf scanout |
+| 8 | MultiCodec | Multiple video codec support |
+| 9 | CodecMJPEG | MJPEG video codec |
+| 10 | CodecVP8 | VP8 video codec |
+| 11 | CodecH264 | H.264/AVC video codec |
+| 12 | PrefVideoCodecType | Client video codec preference |
+| 13 | CodecVP9 | VP9 video codec |
+| 14 | CodecH265 | H.265/HEVC video codec |
+
+### GL Scanout
+
+When `GLScanout` is supported, the server can send GPU-rendered frames directly
+to the client using DMA-buf file descriptors, bypassing software rendering.
+
+**GL Scanout Message (ID 133):**
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     int32   fd (DMA-buf file descriptor)
+4       4     uint32  width
+8       4     uint32  height
+12      4     uint32  stride
+16      4     uint32  drm_fourcc (DRM pixel format)
+20      4     uint32  flags (1=Y0_TOP)
+```
+
+## Inputs Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | KeyScancode | Raw scancode input supported (key_scancode message) |
+
+## Playback Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | CELT_0_5_1 | CELT 0.5.1 audio codec (deprecated) |
+| 1 | Volume | Per-channel volume control |
+| 2 | Latency | Audio latency reporting |
+| 3 | Opus | Opus audio codec |
+
+## Record Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | CELT_0_5_1 | CELT 0.5.1 audio codec (deprecated) |
+| 1 | Volume | Per-channel volume control |
+| 2 | Opus | Opus audio codec |
+
+## SpiceVMC Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | DataCompressLZ4 | LZ4 compression for VMC data |
+
+## Capability Bitmap Encoding
+
+Capabilities are transmitted as a bitmap where each bit position corresponds
+to a specific capability. The bitmap is sent as an array of 32-bit words.
+
+```python
+# Example: Check if capability N is supported
+def has_capability(caps_bitmap, cap_num):
+    word_index = cap_num // 32
+    bit_index = cap_num % 32
+    return (caps_bitmap[word_index] >> bit_index) & 1
+
+# Example: Set capability N
+def set_capability(caps_bitmap, cap_num):
+    word_index = cap_num // 32
+    bit_index = cap_num % 32
+    caps_bitmap[word_index] |= (1 << bit_index)
+```
+
+## Recommended Capability Set
+
+For a modern SPICE client, the recommended minimum capabilities are:
+
+**Common:**
+- AuthSelection (0)
+- AuthSpice (1)
+- MiniHeader (3)
+
+**Display:**
+- SizedStream (0)
+- MonitorsConfig (1)
+- StreamReport (4)
+- LZ4Compression (5)
+- MultiCodec (8)
+- CodecMJPEG (9)
+- CodecVP8 (10)
+- CodecH264 (11)
+
+**Playback/Record:**
+- Volume (1)
+- Opus (3/2)
+
+**Inputs:**
+- KeyScancode (0)
+
+## Related Documentation
+
+- [Link Protocol](spice-link-protocol.md) - Capability exchange during handshake
+- [Protocol Overview](protocol-overview.md) - High-level protocol structure
+- [Channel Protocols](channel-protocols.md) - Per-channel message formats
+- [Keyboard Scancodes](scancodes.md) - KeyScancode capability usage
+- [Compression Protocols](compression-protocols.md) - LZ4/GLZ compression details

--- a/docs/channel-protocols.md
+++ b/docs/channel-protocols.md
@@ -1,0 +1,908 @@
+# SPICE Channel Protocols
+
+This document describes the message formats for each SPICE channel type. All
+messages follow the standard header format described in the
+[Protocol Overview](protocol-overview.md).
+
+**Note**: Message IDs documented here are from Kerbside's internal constants
+(`kerbside/spiceprotocol/packets/constants.py`) and match the values used in
+Kerbside's traffic inspection and audit logging. Some IDs may differ from the
+official SPICE protocol specification for historical reasons.
+
+## Standard Message Header
+
+All channel messages use this header:
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  message_type
+2       4     uint32  message_size (payload length)
+6+      var   bytes   payload
+```
+
+## Main Channel (Type 1)
+
+The main channel handles session control and channel negotiation.
+
+### Client to Server Messages
+
+| ID  | Message           | Description |
+|----:|-------------------|-------------|
+| 1   | ack_sync          | Acknowledge sync generation |
+| 2   | ack               | Acknowledge message |
+| 3   | pong              | Response to ping |
+| 4   | migrate_flush_mark| Migration marker |
+| 5   | migrate_data      | Migration data |
+| 6   | disconnecting     | Client disconnecting |
+| 104 | attach_channels   | Request to attach additional channels |
+
+### Server to Client Messages
+
+| ID  | Message        | Description |
+|----:|----------------|-------------|
+| 1   | migrate        | Migration request |
+| 2   | migrate_data   | Migration data |
+| 3   | set_ack        | Configure acknowledgement window |
+| 4   | ping           | Ping request |
+| 5   | wait_for_channels | Wait for channel traffic |
+| 6   | disconnecting  | Server disconnecting |
+| 7   | notify         | Notification message |
+| 103 | init           | Session initialization |
+| 104 | channels_list  | Available channels list |
+
+### Main Init Message (Server, ID 103)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  session_id
+4       4     uint32  display_channels_hint
+8       4     uint32  supported_mouse_modes
+12      4     uint32  current_mouse_mode
+16      4     uint32  agent_connected
+20      4     uint32  agent_tokens
+24      4     uint32  multi_media_time
+28      4     uint32  ram_hint
+```
+
+### Channels List Message (Server, ID 104)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  num_channels
+4+      2*N   struct  channel entries
+
+Each channel entry:
+0       1     uint8   channel_type
+1       1     uint8   channel_id
+```
+
+## Display Channel (Type 2)
+
+The display channel handles screen updates and drawing operations.
+
+### Client to Server Messages
+
+| ID  | Message | Description |
+|----:|---------|-------------|
+| 101 | init    | Display initialization |
+
+### Display Init Message (Client, ID 101)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   cache_id
+1       8     uint64  cache_size
+9       1     uint8   glz_dict_id
+10      4     uint32  dict_window_size
+```
+
+### Server to Client Messages
+
+| ID  | Message                | Description |
+|----:|------------------------|-------------|
+| 101 | mode                   | Display mode change |
+| 102 | mark                   | Display mark |
+| 103 | reset                  | Reset display state |
+| 104 | copy_bits              | Copy bits operation |
+| 105 | invalidate_list        | Invalidate regions |
+| 106 | invalidate_all_pixmaps | Invalidate all pixmaps |
+| 107 | invalidate_palette     | Invalidate palette |
+| 108 | invalidate_all_palettes| Invalidate all palettes |
+| 122 | stream_create          | Create video stream |
+| 123 | stream_data            | Video stream data |
+| 124 | stream_clip            | Stream clipping region |
+| 125 | stream_destroy         | Destroy stream |
+| 126 | stream_destroy_all     | Destroy all streams |
+| 302 | draw_fill              | Fill rectangle |
+| 303 | draw_opaque            | Opaque draw |
+| 304 | draw_copy              | Copy with ROP |
+| 305 | draw_blend             | Alpha blend |
+| 306 | draw_blackness         | Fill black |
+| 307 | draw_whiteness         | Fill white |
+| 308 | draw_invers            | Invert region |
+| 309 | draw_rop3              | ROP3 operation |
+| 310 | draw_stroke            | Stroke path |
+| 311 | draw_text              | Draw text |
+| 312 | draw_transparent       | Transparent draw |
+| 313 | draw_alpha_blend       | Alpha blend composite |
+| 314 | surface_create         | Create surface |
+| 315 | surface_destroy        | Destroy surface |
+| 316 | stream_data_sized      | Sized stream data |
+| 317 | monitors_config        | Monitor configuration |
+| 318 | draw_composite         | Composite operation |
+| 319 | stream_activate_report | Stream activity report |
+| 320 | gl_scanout_unix        | GL scanout (Unix) |
+| 321 | gl_draw                | GL draw |
+
+### Surface Create Message (Server, ID 314)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  surface_id
+4       4     uint32  width
+8       4     uint32  height
+12      4     uint32  format
+16      4     uint32  flags
+```
+
+### Draw Copy Message (Server, ID 304)
+
+This is one of the most common display messages, used for copying image data.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+-- SpiceMsgDisplayBase --
+0       4     uint32  surface_id
+4       4     uint32  rect_top
+8       4     uint32  rect_left
+12      4     uint32  rect_bottom
+16      4     uint32  rect_right
+20      1     uint8   clip_type
+
+-- Clip Rectangles (if clip_type == 1) --
+21      4     uint32  num_rects
+25+     16*N  struct  rectangles
+
+-- Source Info --
+var     4     uint32  source_image_offset
+var     4     uint32  src_rect_top
+var     4     uint32  src_rect_left
+var     4     uint32  src_rect_bottom
+var     4     uint32  src_rect_right
+var     2     uint16  raster_operations
+var     1     uint8   scale_mode
+
+-- Mask --
+var     1     uint8   mask_flags
+var     4     uint32  mask_pos_x
+var     4     uint32  mask_pos_y
+var     4     uint32  mask_bitmap_address
+
+-- Image Data --
+var     var   struct  image (see Image Format below)
+```
+
+### Clip Types
+
+| Value | Type  | Description |
+|------:|-------|-------------|
+| 0     | none  | No clipping |
+| 1     | rects | Rectangle list |
+| 2     | path  | Path clipping |
+
+### Raster Operations
+
+| Bit  | Operation      |
+|-----:|----------------|
+| 0    | inverse_src    |
+| 1    | inverse_brush  |
+| 2    | inverse_dest   |
+| 3    | put            |
+| 4    | or             |
+| 5    | and            |
+| 6    | xor            |
+| 7    | blackness      |
+| 8    | whiteness      |
+| 9    | inverse        |
+| 10   | inverse_result |
+
+### Scale Modes
+
+| Value | Mode        |
+|------:|-------------|
+| 0     | interpolate |
+| 1     | nearest     |
+
+### Image Format
+
+Images in display messages use this header:
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       8     uint64  image_id
+8       1     uint8   type
+9       1     uint8   flags
+10      4     uint32  width
+12      4     uint32  height
+16+     var   bytes   image_data (format-specific)
+```
+
+### Image Types
+
+| Value | Type        | Description |
+|------:|-------------|-------------|
+| 0     | pixmap      | Uncompressed pixmap |
+| 1     | quic        | QUIC compression |
+| 100   | lz_palette  | LZ with palette |
+| 101   | lz_rgb      | LZ RGB compression |
+| 102   | glz_rgb     | GLZ with dictionary |
+| 103   | from_cache  | Reference to cached image |
+
+### LZ/GLZ Image Header
+
+For LZ and GLZ compressed images:
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  data_size
+
+-- LZ Header (big-endian) --
+4       4     bytes   magic ("  ZL")
+8       2     uint16  version_major
+10      2     uint16  version_minor
+12      3     bytes   padding
+15      1     uint8   type
+16      4     uint32  width
+20      4     uint32  height
+24      4     uint32  stride
+28      4     uint32  top_down
+
+-- For GLZ only --
+28      8     uint64  image_id
+36      4     uint32  win_head_dist
+
+-- Compressed data follows --
+```
+
+### LZ Image Types
+
+| Value | Type        | Description |
+|------:|-------------|-------------|
+| 0     | invalid     | Invalid |
+| 1     | palette1_le | 1-bit palette (LE) |
+| 2     | palette1_be | 1-bit palette (BE) |
+| 3     | palette4_le | 4-bit palette (LE) |
+| 4     | palette4_be | 4-bit palette (BE) |
+| 5     | palette8    | 8-bit palette |
+| 6     | rgb16       | 16-bit RGB |
+| 7     | rgb24       | 24-bit RGB |
+| 8     | rgb32       | 32-bit RGB |
+| 9     | rgba        | 32-bit RGBA |
+| 10    | xxxa        | 32-bit with alpha |
+
+## Inputs Channel (Type 3)
+
+The inputs channel handles keyboard and mouse input from client to server.
+See [Keyboard Scancodes](scancodes.md) for a complete scancode reference.
+
+### Client to Server Messages
+
+| ID  | Message        | Description |
+|----:|----------------|-------------|
+| 101 | key_down       | Key pressed |
+| 102 | key_up         | Key released |
+| 103 | key_modifiers  | Modifier state change |
+| 104 | key_scancode   | Raw scancode |
+| 111 | mouse_motion   | Relative mouse movement |
+| 112 | mouse_position | Absolute mouse position |
+| 113 | mouse_press    | Mouse button pressed |
+| 114 | mouse_release  | Mouse button released |
+
+### Server to Client Messages
+
+| ID  | Message          | Description |
+|----:|------------------|-------------|
+| 101 | init             | Inputs initialization |
+| 102 | key_modifiers    | Current modifier state |
+| 111 | mouse_motion_ack | Acknowledge mouse motion |
+
+### Key Down/Up Message (Client, ID 101/102)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  scancode
+```
+
+### Key Modifiers Message (ID 103/102)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  modifiers
+```
+
+Modifier flags:
+| Bit | Modifier    |
+|----:|-------------|
+| 0   | Scroll Lock |
+| 1   | Num Lock    |
+| 2   | Caps Lock   |
+
+### Key Scancode Message (Client, ID 104)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       N     uint8[] scancodes (N bytes, one per scancode)
+```
+
+### Mouse Motion Message (Client, ID 111)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     int32   delta_x
+4       4     int32   delta_y
+8       2     uint16  button_state
+```
+
+### Mouse Position Message (Client, ID 112)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  x
+4       4     uint32  y
+8       2     uint16  button_state
+10      1     uint8   display_id
+```
+
+### Mouse Press/Release Message (Client, ID 113/114)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   button
+1       2     uint16  button_state
+3       1     uint8   display_id
+```
+
+### Mouse Buttons
+
+| Value | Button |
+|------:|--------|
+| 0 | Invalid |
+| 1 | Left |
+| 2 | Middle |
+| 3 | Right |
+| 4 | Wheel Up |
+| 5 | Wheel Down |
+| 6 | Side |
+| 7 | Extra |
+
+### Mouse Button State Masks
+
+The `button_state` field is a bitmask of currently pressed buttons:
+
+| Bit | Mask | Button |
+|----:|-----:|--------|
+| 0 | 0x01 | Left |
+| 1 | 0x02 | Middle |
+| 2 | 0x04 | Right |
+| 3 | 0x08 | Wheel Up |
+| 4 | 0x10 | Wheel Down |
+| 5 | 0x20 | Side |
+| 6 | 0x40 | Extra |
+
+### Mouse Modes
+
+| Value | Mode | Description |
+|------:|------|-------------|
+| 1 | Server | Server controls cursor; client sends relative motion |
+| 2 | Client | Client controls cursor; client sends absolute position |
+
+## Cursor Channel (Type 4)
+
+The cursor channel handles cursor shape and position updates.
+
+### Server to Client Messages
+
+| ID  | Message        | Description |
+|----:|----------------|-------------|
+| 101 | init           | Cursor initialization |
+| 102 | reset          | Reset cursor state |
+| 103 | set            | Set cursor shape and position |
+| 104 | move           | Move cursor |
+| 105 | hide           | Hide cursor |
+| 106 | trail          | Set cursor trail |
+| 107 | invalidate_one | Invalidate cached cursor |
+| 108 | invalidate_all | Invalidate all cached cursors |
+
+### Cursor Init Message (Server, ID 101)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  x
+2       2     uint16  y
+4       2     uint16  trail_length
+6       2     uint16  trail_frequency
+8       1     uint8   visible
+
+-- SpiceCursor follows if size permits --
+9       4     uint32  flags
+13      8     uint64  unique_id
+21      2     uint16  cursor_type
+23      2     uint16  width
+25      2     uint16  height
+27      2     uint16  hot_spot_x
+29      2     uint16  hot_spot_y
+31+     var   bytes   cursor_data
+```
+
+### Cursor Types
+
+| Value | Type | Description |
+|------:|------|-------------|
+| 0 | Alpha | 32-bit ARGB with alpha channel |
+| 1 | Mono | Monochrome (1-bit) |
+| 2 | Color4 | 4-bit palette indexed |
+| 3 | Color8 | 8-bit palette indexed |
+| 4 | Color16 | 16-bit RGB |
+| 5 | Color24 | 24-bit BGR |
+| 6 | Color32 | 32-bit xRGB (no alpha) |
+
+### Cursor Flags
+
+| Bit | Flag | Description |
+|----:|------|-------------|
+| 0 | None | No special flags |
+| 1 | Cache Me | Server requests client to cache this cursor |
+| 2 | From Cache | Use previously cached cursor (data not included) |
+
+### Cursor Set Message (Server, ID 103)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  x
+2       2     uint16  y
+4       1     uint8   visible
+
+-- SpiceCursor follows --
+```
+
+### Cursor Move Message (Server, ID 104)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  x
+2       2     uint16  y
+```
+
+### Cursor Trail Message (Server, ID 106)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  trail_length
+2       2     uint16  trail_frequency
+```
+
+### Cursor Invalidate One Message (Server, ID 107)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       8     uint64  cursor_id
+```
+
+## Port Channel (Type 9)
+
+The port channel handles device redirection, primarily USB devices through the
+VMC (Virtual Machine Communication) protocol.
+
+### Client and Server Messages
+
+| ID  | Message            | Description |
+|----:|--------------------|-------------|
+| 101 | vmc_data           | VMC protocol data |
+| 102 | vmc_compressed_data| Compressed VMC data |
+
+### VMC Data Message (ID 101)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  vmc_type (USB redir message type)
+4       4     uint32  vmc_length
+8       4     uint32  vmc_id
+12+     var   bytes   vmc_payload (see USB Redirection)
+```
+
+For detailed VMC/USB redirection message formats, see
+[USB Redirection](usb-redirection.md).
+
+## Common Message Details
+
+### Ping Message (Server)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  ping_id
+4       8     uint64  timestamp
+```
+
+### Pong Message (Client)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  ping_id
+4       8     uint64  timestamp
+```
+
+### Set Ack Message (Server)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  generation
+4       4     uint32  window
+```
+
+### Ack Sync Message (Client)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  generation
+```
+
+### Ack Message (Client)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  generation
+```
+
+Note: Display channel ACKs may have zero-length payloads.
+
+### Disconnecting Message
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       8     uint64  timestamp
+4       4     uint32  reason (error code)
+```
+
+### Notify Message (Server)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       8     uint64  timestamp
+8       4     uint32  severity
+12      4     uint32  visibility
+16      4     uint32  what (topic code)
+20      4     uint32  message_length
+24      N     bytes   message (UTF-8, null-terminated)
+```
+
+Severity values:
+| Value | Severity |
+|------:|----------|
+| 0     | info     |
+| 1     | warn     |
+| 2     | error    |
+
+Visibility values:
+| Value | Visibility |
+|------:|------------|
+| 0     | low        |
+| 1     | medium     |
+| 2     | high       |
+
+## Playback Channel (Type 5)
+
+The playback channel handles audio output from the VM to the client.
+
+**Note**: Kerbside proxies this channel transparently without decoding.
+
+### Server to Client Messages
+
+| ID  | Message | Description |
+|----:|---------|-------------|
+| 101 | data    | Audio data packet |
+| 102 | mode    | Audio mode/codec configuration |
+| 103 | start   | Start audio playback |
+| 104 | stop    | Stop audio playback |
+| 105 | volume  | Volume control |
+| 106 | mute    | Mute control |
+| 107 | latency | Latency information |
+
+### Playback Mode Message (Server, ID 102)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  time (multimedia time)
+4       4     uint32  mode
+8       var   bytes   codec-specific data
+```
+
+Mode values:
+| Value | Mode      | Description |
+|------:|-----------|-------------|
+| 1     | RAW       | Uncompressed PCM |
+| 2     | CELT_0_5_1| CELT 0.5.1 codec (deprecated) |
+| 3     | OPUS      | Opus codec (recommended) |
+
+**OPUS Codec Specifications:**
+- Frame size: 480 samples
+- Playback frequency: 48000 Hz
+- Channels: 2 (stereo)
+- Max compressed frame: ~480 bytes
+- Max uncompressed frame: 1920 bytes (480 samples × 2 channels × 2 bytes)
+
+### Playback Start Message (Server, ID 103)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  channels (1=mono, 2=stereo)
+4       4     uint32  format (1=S16, 16-bit signed)
+8       4     uint32  frequency (sample rate in Hz)
+```
+
+### Playback Data Message (Server, ID 101)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  time (multimedia time)
+4       var   bytes   audio data
+```
+
+### Playback Volume Message (Server, ID 105)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   num_channels
+1       2*N   uint16  volume per channel (0-65535)
+```
+
+## Record Channel (Type 6)
+
+The record channel handles audio input from the client to the VM.
+
+**Note**: Kerbside proxies this channel transparently without decoding.
+
+### Server to Client Messages
+
+| ID  | Message | Description |
+|----:|---------|-------------|
+| 101 | start   | Start recording |
+| 102 | stop    | Stop recording |
+| 103 | volume  | Volume control |
+| 104 | mute    | Mute control |
+
+### Client to Server Messages
+
+| ID  | Message    | Description |
+|----:|------------|-------------|
+| 101 | data       | Audio data packet |
+| 102 | mode       | Audio mode/codec configuration |
+| 103 | start_mark | Start marker |
+
+### Record Start Message (Server, ID 101)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  channels
+4       4     uint32  format (1=S16)
+8       4     uint32  frequency
+```
+
+### Record Data Message (Client, ID 101)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  time (multimedia time)
+4       var   bytes   audio data
+```
+
+## Smartcard Channel (Type 8)
+
+The smartcard channel handles smart card redirection for authentication using
+the VSC (Virtual Smart Card) protocol.
+
+**Note**: Kerbside proxies this channel transparently without decoding.
+
+### Server to Client Messages
+
+| ID  | Message | Description |
+|----:|---------|-------------|
+| 101 | data    | Smartcard data |
+| 102 | error   | Error message |
+
+### Client to Server Messages
+
+| ID  | Message  | Description |
+|----:|----------|-------------|
+| 101 | data     | Smartcard data |
+| 102 | header   | Header information |
+| 103 | reader_add | Reader added |
+| 104 | reader_remove | Reader removed |
+| 105 | atr      | Answer-to-reset data |
+| 106 | error    | Error message |
+
+### VSC Message Types
+
+The smartcard data payload contains VSC (Virtual Smart Card) messages:
+
+| Value | Type | Description |
+|------:|------|-------------|
+| 1 | Init | Initialize VSC session |
+| 2 | Error | Error notification |
+| 3 | ReaderAdd | Smart card reader attached |
+| 4 | ReaderRemove | Smart card reader removed |
+| 5 | ATR | Answer-to-Reset (card identification) |
+| 6 | CardRemove | Smart card removed from reader |
+| 7 | APDU | Application Protocol Data Unit (command/response) |
+| 8 | Flush | Flush pending operations |
+| 9 | FlushComplete | Flush operation completed |
+
+## Video Streaming
+
+The display channel supports video streaming for efficient screen updates.
+
+### Video Codecs
+
+| Value | Codec  | Description |
+|------:|--------|-------------|
+| 1     | MJPEG  | Motion JPEG |
+| 2     | VP8    | VP8 (WebM) |
+| 3     | H264   | H.264/AVC |
+| 4     | VP9    | VP9 (WebM) |
+| 5     | H265   | H.265/HEVC |
+
+### Stream Create Message (Server, ID 122)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       4     uint32  flags (1=TOP_DOWN)
+8       4     uint32  codec_type
+12      8     uint64  reserved
+20      4     uint32  stream_width
+24      4     uint32  stream_height
+28      4     uint32  source_width
+32      4     uint32  source_height
+36      16    struct  destination rect (top, left, bottom, right)
+52      var   struct  clip (type + data)
+```
+
+### Stream Data Message (Server, ID 123)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       4     uint32  multimedia_time
+8       4     uint32  data_size
+12      4     uint32  pad_size (for alignment)
+16      var   bytes   compressed video frame
+```
+
+### Stream Clip Message (Server, ID 124)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       var   struct  clip (type + rectangles)
+```
+
+### Stream Destroy Message (Server, ID 125)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+```
+
+## Additional Image Types
+
+Beyond the basic compression types documented earlier, SPICE supports:
+
+| Value | Type          | Description |
+|------:|---------------|-------------|
+| 0     | PIXMAP        | Uncompressed bitmap |
+| 1     | QUIC          | QUIC compression |
+| 2     | SURFACE       | Reference to existing surface |
+| 3     | JPEG          | JPEG compression |
+| 4     | ZLIB_GLZ_RGB  | Zlib-compressed GLZ |
+| 5     | JPEG_ALPHA    | JPEG with alpha channel |
+| 6     | LZ4           | LZ4 compression |
+| 100   | LZ_PLT        | LZ with palette |
+| 101   | LZ_RGB        | LZ RGB |
+| 102   | GLZ_RGB       | GLZ with dictionary |
+| 103   | FROM_CACHE    | Cached image reference |
+
+## Raster Operations (ROP)
+
+Drawing commands use raster operation flags to control how pixels are combined:
+
+| Bit | Flag | Description |
+|----:|------|-------------|
+| 0 | INVERS_SRC | Invert source before operation |
+| 1 | INVERS_BRUSH | Invert brush before operation |
+| 2 | INVERS_DEST | Invert destination before operation |
+| 3 | OP_PUT | Copy operation |
+| 4 | OP_OR | Bitwise OR |
+| 5 | OP_AND | Bitwise AND |
+| 6 | OP_XOR | Bitwise XOR |
+| 7 | OP_BLACKNESS | Fill with black |
+| 8 | OP_WHITENESS | Fill with white |
+| 9 | OP_INVERS | Invert destination |
+| 10 | INVERS_RES | Invert result after operation |
+
+## Clip Types
+
+| Value | Type | Description |
+|------:|------|-------------|
+| 0 | none | No clipping |
+| 1 | rects | Rectangular clipping region |
+| 2 | path | Path-based clipping |
+
+## Brush Types
+
+| Value | Type | Description |
+|------:|------|-------------|
+| 0 | none | No brush |
+| 1 | solid | Solid color fill |
+| 2 | pattern | Pattern fill |
+
+## Scale Modes
+
+| Value | Mode | Description |
+|------:|------|-------------|
+| 0 | interpolate | Bilinear interpolation |
+| 1 | nearest | Nearest-neighbor sampling |
+
+## Mouse Button Masks
+
+| Bit | Button |
+|----:|--------|
+| 0   | Left   |
+| 1   | Middle |
+| 2   | Right  |
+| 3   | Up (scroll) |
+| 4   | Down (scroll) |
+| 5   | Side   |
+| 6   | Extra  |
+
+## Related Documentation
+
+- [Protocol Overview](protocol-overview.md) - High-level protocol introduction
+- [Link Protocol](spice-link-protocol.md) - Connection handshake details
+- [USB Redirection](usb-redirection.md) - USB device redirection protocol
+- [VD Agent Protocol](vd-agent-protocol.md) - Guest agent for clipboard and file transfer

--- a/docs/compression-protocols.md
+++ b/docs/compression-protocols.md
@@ -1,0 +1,251 @@
+# SPICE Compression Protocols
+
+This document describes the proprietary graphics compression formats implemented
+by the SPICE protocol, specifically the LZ and GLZ formats. These formats are
+used by SPICE to compress display updates for transmission to clients.
+
+## Overview
+
+SPICE implements several graphics compression formats, but only two have been
+commonly observed for non-video console sessions:
+
+- **LZ** (Lempel-Ziv) - A dictionary compression algorithm
+- **GLZ** (Global LZ) - An extension of LZ that references previous images
+
+Both formats use a progressive dictionary compression scheme where previously
+decompressed pixels form the dictionary for later decompression. Kerbside
+includes a simple LZ/GLZ decompression tool (`kerbside-util`) that can
+decompress these formats and convert them to PNG for inspection.
+
+## LZ Compression
+
+LZ compression as implemented in SPICE is a progressive dictionary compression
+scheme. The dictionary is not transmitted separately from the image - instead,
+previously decompressed elements of the image form the dictionary for later
+decompression. As the image is processed (generally from top-left), runs of
+previously decompressed pixels are referenced where they reappear.
+
+### LZ Image Header
+
+LZ images start with a header containing the following fields. Note that
+multi-byte values are **big-endian**, unlike most of the SPICE protocol which
+is little-endian.
+
+| Field | Size | Description |
+|-------|------|-------------|
+| Magic | 4 bytes | Always `"  ZL"` (two spaces followed by ZL) in UTF-8 |
+| Version Major | UINT16 | Always 1 |
+| Version Minor | UINT16 | Always 1 |
+| Padding | 3 bytes | Null bytes |
+| Image Type | UINT8 | See Image Types table below |
+| Image Width | UINT32 | Width of the image in pixels |
+| Image Height | UINT32 | Height of the image in pixels |
+| Image Stride | UINT32 | Length of one row in decompressed bytes (e.g., 1024 pixels = 4096 stride for RGB32) |
+| Top Down | UINT32 | 1 if image is presented top row first, 0 if vertically flipped |
+
+### Image Types
+
+| Value | Type | Description |
+|------:|------|-------------|
+| 0 | invalid | Invalid/unset |
+| 1 | palette1_le | 1-bit palette, little-endian |
+| 2 | palette1_be | 1-bit palette, big-endian |
+| 3 | palette4_le | 4-bit palette, little-endian |
+| 4 | palette4_be | 4-bit palette, big-endian |
+| 5 | palette8 | 8-bit palette |
+| 6 | rgb16 | 16-bit RGB |
+| 7 | rgb24 | 24-bit RGB |
+| 8 | rgb32 | 32-bit RGB (actually BGR with implied alpha) |
+| 9 | rgba | RGB with alpha |
+| 10 | xxxa | Alpha channel only |
+
+**Note**: In practice, the SPICE server implementation typically uses RGB32 for
+display compression. Despite the name, this format is three bytes of **BGR**
+(blue, green, red - reversed from traditional RGB order) with an implied alpha
+channel of 0xFF.
+
+### LZ Compressed Data Format
+
+After the header, the compressed image data follows as a sequence of unsigned
+single-byte commands with variable-length arguments.
+
+#### Direct Pixel Commands (0-32)
+
+If the command byte is 32 or less, it instructs the decoder to include N+1
+direct pixels as output, where N is the command value.
+
+For RGB32 format, a command of 0 produces:
+```
+[0] [B][G][R]
+```
+
+A command of 3 produces:
+```
+[3] [B0][G0][R0] [B1][G1][R1] [B2][G2][R2] [B3][G3][R3]
+```
+
+#### Reference Commands (> 32)
+
+Commands greater than 32 reference previously decompressed pixels. The command
+byte is structured as:
+
+```
+[LLLOOOOO]
+ ^^^----- Length (top 3 bits)
+    ^^^^^- Pixel offset (bottom 5 bits)
+```
+
+**Decoding Length:**
+
+Extract the length from the top 3 bits. If the length field is maxed out at 7
+(binary 111), additional length bytes follow. Read bytes and add them to the
+length until a byte that is not 0xFF is encountered.
+
+Example encoding for 512 pixels:
+```
+[111-----][11111111][11111010] = length: 7 + 255 + 250 = 512
+```
+
+**Decoding Pixel Offset:**
+
+The 5 bits from the command byte form the high bits of the pixel offset. An
+additional byte is always read:
+
+```
+[---OOOOO][MMMMMMMM] = OOOOOMMMMMMMMM (offset)
+```
+
+If the embedded offset bits are all ones (11111) AND the additional byte is
+0xFF (255), this indicates an extended offset. Read two more bytes as a
+big-endian UINT16 and add 8191:
+
+```
+[---11111][length...][11111111][HHHHHHHH][LLLLLLLL]
+= HHHHHHHHLLLLLLLL + 8191 (offset for values > 8192)
+```
+
+Finally, add 1 to the offset (cannot reference the current pixel).
+
+**Applying the Reference:**
+
+- If offset = 1: Duplicate the immediately prior pixel `length` times
+- Otherwise: Copy `length` pixels from (current position - offset)
+
+### Implementation Reference
+
+For a working implementation, see `kerbside/utilities/lz.py` in the Kerbside
+codebase.
+
+## GLZ Compression
+
+GLZ (Global LZ) extends LZ by allowing references to pixels from previously
+decompressed images in the session, not just the current image. This is
+efficient when frames have small differences - only the delta and context
+information need to be transmitted.
+
+### GLZ Image Header
+
+GLZ images use a similar but distinct header format. Multi-byte values are
+**big-endian**.
+
+| Field | Size | Description |
+|-------|------|-------------|
+| Magic | 4 bytes | Always `"  ZL"` (two spaces followed by ZL) in UTF-8 |
+| Version Major | UINT16 | Always 1 |
+| Version Minor | UINT16 | Always 1 |
+| Image Type + Top Down | UINT8 | Packed: bottom 4 bits = image type, top 4 bits = top down flag |
+| Image Width | UINT32 | Width in pixels |
+| Image Height | UINT32 | Height in pixels |
+| Image Stride | UINT32 | Length of one row in decompressed bytes |
+| Image ID | UINT64 | Unique identifier for this image in the dictionary |
+| Window Header Distance | UINT32 | Distance between current image ID and referenced image |
+
+**Note**: The SPICE server always starts image IDs from zero. There appear to be
+bugs when using very large IDs.
+
+### GLZ Compressed Data Format
+
+Direct pixel commands (0-32) work identically to LZ compression.
+
+For reference commands (> 32), the command byte structure differs:
+
+```
+[LLLFOOOO]
+ ^^^----- Length (top 3 bits)
+    ^---- Pixel flag (1 bit)
+     ^^^^- Pixel offset (bottom 4 bits)
+```
+
+**Decoding Length:**
+
+Same as LZ - if the length field is maxed out at 7, read additional bytes
+and add them to the length until a non-0xFF byte is encountered.
+
+**Decoding Pixel Offset:**
+
+Unlike LZ, an additional offset byte is **always** read and placed above the
+embedded offset:
+
+```
+[---FOOOO][length...][MMMMMMMM] = MMMMMMMMOOOO (offset)
+```
+
+**Decoding Image Distance:**
+
+Read another byte. The top 2 bits form the "image flag", and processing depends
+on the pixel flag value:
+
+**Pixel Flag = 0:**
+
+The bottom 6 bits are the image distance. The image flag indicates how many
+additional distance bytes to read, which are prepended:
+
+```
+[10DDDDDD][EEEEEEEE][FFFFFFFF]
+= FFFFFFFFEEEEEEEEDDDDDD (distance)
+```
+
+**Pixel Flag = 1:**
+
+Replace the pixel flag with bit 5 of the byte. The bottom 5 bits are added
+to the pixel offset at bit position 12:
+
+```
+[---1OOOO][length...][MMMMMMMM][--PNNNNN]
+= NNNNNMMMMMMMMOOOO (17-bit offset)
+```
+
+Where P is the new pixel flag (bit 5 of the byte).
+
+Then read `image_flag` bytes of image distance. If the new pixel flag is
+non-zero, read one final offset byte and add it at bit position 17, allowing
+for 25-bit offsets.
+
+**Applying the Reference:**
+
+- If image distance = 0: Reference is within the current image (like LZ)
+  - Offset 1: Duplicate previous pixel `length` times
+  - Other offset: Copy `length` pixels from (current position - offset)
+- If image distance > 0: Reference is to a previous image
+  - Calculate target image ID = current image ID - distance
+  - Offset is from the **start** of the target image
+  - Copy `length` pixels from that location
+
+### Implementation Reference
+
+For a working implementation, see `kerbside/utilities/glz.py` in the Kerbside
+codebase.
+
+## Utility Tool
+
+Kerbside includes `kerbside-util` which can:
+
+- Decompress LZ and GLZ compressed images
+- Convert compressed images to PNG for inspection
+- Useful for debugging display channel issues
+
+## Related Documentation
+
+- [Protocol Overview](protocol-overview.md) - High-level SPICE protocol
+- [Channel Protocols](channel-protocols.md) - Display channel message formats
+- [Capabilities](capabilities.md) - LZ4Compression and PrefCompression capabilities

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,107 @@
+# Configuring Kerbside
+
+Kerbside is configured via environment variables (prefixed with `KERBSIDE_`) or
+an INI configuration file at `/etc/kerbside/kerbside.ini`. Environment variables
+take priority over INI file settings. See `etc/kerbside.conf.example` for a
+complete configuration example.
+
+**Note**: This documentation should match `kerbside/config.py`. If you find
+discrepancies, the source code in `config.py` is authoritative.
+
+## Basic Settings
+
+| Configuration Option | Type | Description |
+|---------------------|------|-------------|
+| SOURCES_PATH | String (default ./sources.yaml) | The path the console sources file (sources.yaml) resides at. |
+| SQL_URL | String | The SQLAlchemy SQL connection URL for the VDI proxy database. |
+| CONSOLE_TOKEN_DURATION | Integer (default 1) | The number of minutes a console access token should be valid for. |
+| AUTH_SECRET_SEED | String (no default) | A random string used to hash the signatures on JWT authentication tokens. Knowledge of this string is required to sign a JWT. |
+| API_TOKEN_DURATION | Integer (default 60) | The number of minutes that a JWT is valid for after being issued. Importantly, Keystone credentials are only validated on JWT creation, so it is possible for a JWT to outlive the Keystone user access token it encapsulates. |
+
+## TLS Settings
+
+| Configuration Option | Type | Description |
+|---------------------|------|-------------|
+| CACERT_PATH | String (default /etc/pki/CA/ca-cert.pem) | The path to the TLS CA certificate. |
+| PROXY_HOST_SUBJECT | String | The TLS Host-Subject that matches the one set for VDI proxy certificates. |
+| PROXY_HOST_CERT_PATH | String (default /etc/pki/CA/certs/proxy.pem) | The path to the TLS certificate for the proxy. |
+| PROXY_HOST_CERT_KEY_PATH | String (default /etc/pki/CA/certs/proxy-key.pem) | The path to the file containing the key for the proxy TLS certificate. |
+
+## Keystone Settings
+
+These settings configure Keystone integration for OpenStack deployments.
+
+| Configuration Option | Type | Description |
+|---------------------|------|-------------|
+| KEYSTONE_AUTH_URL | String (no default) | The URL including scheme and port that is to be used to authenticate the Keystone service account for the proxy, and subsequently all proxy user authentications. |
+| KEYSTONE_AUTH_VERIFY | Boolean or String (default True) | Whether to verify TLS sessions to Keystone. False to disable verification; True to verify using system CA bundle; or a path to a specific CA certificate or bundle. |
+| KEYSTONE_SERVICE_AUTH_USER | String (no default) | The service account username. |
+| KEYSTONE_SERVICE_AUTH_PASSWORD | String (no default) | The password for the service account. |
+| KEYSTONE_SERVICE_AUTH_USER_DOMAIN_ID | String (default "default") | The domain the service account resides in. |
+| KEYSTONE_SERVICE_AUTH_PROJECT | String (default "admin") | The project the service account resides in. |
+| KEYSTONE_SERVICE_AUTH_PROJECT_DOMAIN_ID | String (default "default") | The project domain the service account resides in. |
+| KEYSTONE_ACCESS_GROUP | String (default "kerbside") | The Keystone group that users wishing to access the VDI proxy administrative interface or REST API must be a member of. |
+
+## Network Settings
+
+| Configuration Option | Type | Description |
+|---------------------|------|-------------|
+| PUBLIC_FQDN | String | The DNS name for the load balancers serving all Kerbside traffic. This needs to be configured to ensure DNS and the SSL certificates for the VDI proxy match or the certificates will be invalid. |
+| PUBLIC_SECURE_PORT | Integer (default 5900) | Port secure connections should connect to on the PUBLIC_FQDN. This can be different from VDI_SECURE_PORT if there is a load balancing layer in front of Kerbside. |
+| PUBLIC_INSECURE_PORT | Integer (default 5901) | Port insecure connections should connect to on the PUBLIC_FQDN. This can be different from VDI_INSECURE_PORT if there is a load balancing layer in front of Kerbside. |
+| NODE_NAME | String (default "kerbside") | A unique name for each machine or container running the VDI proxy. This is used for logging and tracking purposes. |
+| VDI_ADDRESS | String (default 0.0.0.0) | The IPv4 address to bind the SPICE proxy to. |
+| VDI_SECURE_PORT | Integer (default 5900) | The port the VDI proxy will serve TLS SPICE sessions over. |
+| VDI_INSECURE_PORT | Integer (default 5901) | The port the VDI proxy will serve insecure SPICE sessions over. These insecure sessions are only used to redirect the user to the secure port. |
+
+## Traffic Inspection
+
+Being able to inspect traffic being passed by the proxy is useful during both
+development and whilst diagnosing issues in production but has obvious privacy
+concerns.
+
+The VDI proxy may be configured to log details of traffic for all sessions by
+setting the `KERBSIDE_TRAFFIC_INSPECTION` environment variable to "1". This will
+write session traffic details to the directory configured by
+`KERBSIDE_TRAFFIC_OUTPUT_PATH`, in a sub directory per session identifier.
+Additionally, more detailed information can be logged by also setting
+`KERBSIDE_TRAFFIC_INSPECTION_INTIMATE` to "1".
+
+Traffic inspection is per proxy not per session and implies a restart of the
+proxy before it is enabled. This ensures that users are aware that traffic
+inspection has been enabled. If traffic inspection is enabled, audit messages
+are recorded per channel logged (as not all channels need to flow through the
+same proxy machine). Additionally, the display channel is altered to show a
+dashed red and yellow border to provide a visual warning that this inspection
+is occurring.
+
+| Configuration Option | Type | Description |
+|---------------------|------|-------------|
+| TRAFFIC_INSPECTION | Boolean (default False) | Whether to log detailed traffic information. Defaults to false, but can be useful for debugging service issues in production. |
+| TRAFFIC_INSPECTION_INTIMATE | Boolean (default False) | If TRAFFIC_INSPECTION is true and this option is also set to true, then log intimate debug details of sessions including keystrokes and all display frames. |
+| TRAFFIC_OUTPUT_PATH | String (default empty) | Where to write traffic inspection logs to. This must be set if TRAFFIC_INSPECTION is True. |
+
+## Logging and Monitoring Settings
+
+The VDI proxy provides Prometheus style metrics on a configurable port (default
+13003). These metric values are also logged for later processing if desired.
+
+Values tracked include:
+
+- Number of active console sessions
+- Number of active console channels
+- Bandwidth and latency information for each console channel
+- REST API request statuses as a metric with labels for each HTTP status code
+- REST API request response latency as a histogram per HTTP status code
+
+| Configuration Option | Type | Description |
+|---------------------|------|-------------|
+| LOG_OUTPUT_PATH | String (default empty) | Where to write logs to. If "stdout", then stdout is used. If blank, syslog is used. |
+| LOG_OUTPUT_JSON | Boolean (default False) | If true, log entries are in JSON format. |
+| LOG_VERBOSE | Boolean (default False) | Whether to log verbose debugging information. |
+| PROMETHEUS_METRICS_PORT | Integer (default 13003) | The TCP port that the prometheus metrics HTTP server will listen on. |
+
+## Related Documentation
+
+- [Console Sources](console-sources.md) - Configuring sources.yaml
+- [Proxy Architecture](proxy-architecture.md) - Internal proxy design

--- a/docs/console-sources.md
+++ b/docs/console-sources.md
@@ -1,0 +1,141 @@
+# Console Sources
+
+Kerbside can connect to the following platforms:
+
+- [Shaken Fist](https://shakenfist.com)
+- [oVirt](https://www.ovirt.org), an Open Source Red Hat supported
+  virtualization system
+- [OpenStack](https://www.openstack.org), an Open Source cloud compute platform
+
+The connection to each platform (a source of consoles, so "console sources") is
+defined in the `sources.yaml` configuration file in YAML format. The path to
+this file is configured via the `SOURCES_PATH` setting.
+
+## How Console Sources Work
+
+Kerbside handles different source types in different ways:
+
+- **Shaken Fist and oVirt**: These sources are queried regularly (once a minute)
+  for a list of available consoles. The consoles are stored in the database and
+  presented in the Kerbside administrative interface.
+
+- **OpenStack**: OpenStack sources are handled differently. Rather than periodic
+  scraping, OpenStack uses on-demand authentication. When a user requests a
+  console via Nova's SPICE console API, Nova provides an authentication token
+  that Kerbside validates against the configured OpenStack source. This means
+  OpenStack consoles appear dynamically when requested rather than being
+  pre-discovered.
+
+It is possible to have more than one console source for a given type, so for
+example the VDI proxy could be used to combine virtual machines from two
+OpenStack clusters together seamlessly.
+
+## Shaken Fist
+
+The following options are used to configure a Shaken Fist console source
+(`type: shakenfist`).
+
+| Option | Description |
+|--------|-------------|
+| source | The name of the source (used as an identifier) |
+| type | The type of the source: `shakenfist` |
+| url | The API URL for the Shaken Fist cluster |
+| username | The Shaken Fist namespace to authenticate to |
+| password | The API key/password to authenticate with |
+| ca_cert | Required: the SSL CA public key certificate to validate API and VDI connections against |
+
+**Note**: The CA certificate is verified against the cluster's advertised
+certificate during initialization. If they don't match, the source will be
+marked as errored.
+
+## oVirt
+
+The following options are used to configure an oVirt console source
+(`type: ovirt`).
+
+| Option | Description |
+|--------|-------------|
+| source | The name of the source (used as an identifier) |
+| type | The type of the source: `ovirt` |
+| url | The oVirt Engine URL (e.g., `https://ovirt.example.org/ovirt-engine`) |
+| username | The username to authenticate to the source as (e.g., `admin@internal`) |
+| password | The password to authenticate with |
+| ca_cert | Required: the SSL CA public key certificate to validate API and VDI connections against |
+
+**Note**: The CA certificate is verified against the engine's PKI certificate
+during initialization. If they don't match, the source will be marked as
+errored.
+
+## OpenStack
+
+OpenStack sources work differently from Shaken Fist and oVirt. Instead of
+periodically scraping for available consoles, Kerbside validates authentication
+tokens issued by Nova when users request SPICE direct console access.
+
+Nova 2025.1 (Epoxy) and later includes native support for SPICE direct consoles
+via the "spice-direct" console type. When a user requests a console, Nova returns
+a URL pointing to Kerbside with an authentication token. Kerbside validates this
+token via Nova's `/os-console-auth-tokens/` API and establishes the proxied
+connection to the hypervisor.
+
+The following options are used to configure an OpenStack console source
+(`type: openstack`).
+
+| Option | Description |
+|--------|-------------|
+| source | The name of the source (used as an identifier) |
+| type | The type of the source: `openstack` |
+| url | The Keystone authentication URL (e.g., `http://keystone.example.org:5000`) |
+| username | The username for the service account |
+| password | The password for the service account |
+| project_name | The OpenStack project name for the service account |
+| user_domain_id | The OpenStack user domain ID (typically "default") |
+| project_domain_id | The OpenStack project domain ID (typically "default") |
+| ca_cert | Optional: the SSL CA public key certificate to validate connections against |
+
+**Note**: OpenStack integration requires Nova 2025.1+ with SPICE direct console
+support enabled. See the
+[Kerbside Patches repository](https://github.com/shakenfist/kerbside-patches)
+for Kolla-Ansible deployment support, and the
+[Nova specification](https://specs.openstack.org/openstack/nova-specs/specs/2025.1/implemented/libvirt-spice-direct-consoles.html)
+for configuration details.
+
+## Example sources.yaml
+
+An example configuration follows:
+
+```yaml
+- source: sfmel
+  type: shakenfist
+  url: https://sfmel.example.org/api
+  username: sfvdi
+  password: ...omitted...
+  ca_cert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+
+- source: ovirt
+  type: ovirt
+  url: https://ovirt.example.org/ovirt-engine
+  username: kerbside@internal
+  password: ...omitted...
+  ca_cert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+
+- source: kolla
+  type: openstack
+  url: http://keystone.example.org:5000
+  username: kerbside
+  password: ...omitted...
+  project_name: service
+  user_domain_id: default
+  project_domain_id: default
+```
+
+## Related Documentation
+
+- [Configuration](configuration.md) - General configuration reference
+- [Proxy Architecture](proxy-architecture.md) - Internal proxy design

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,286 @@
+# Kerbside Documentation
+
+Welcome to the Kerbside documentation.
+
+## Documentation Version
+
+This documentation covers:
+
+- **SPICE Protocol Version**: 2.2 (current as of spice-protocol 0.14)
+- **Kerbside Version**: Verified against `kerbside/spiceprotocol/packets/constants.py`
+- **OpenStack Integration**: Nova 2025.1 (Epoxy) and later
+
+Protocol documentation is derived from the official SPICE protocol sources at
+`gitlab.freedesktop.org/spice/spice-protocol` and verified against Kerbside's
+implementation. Message IDs and constants reflect Kerbside's internal mappings.
+
+## Introduction
+
+Kerbside is a [SPICE](https://spice-space.org/) protocol native VDI proxy
+responsible for providing rich VDI experiences to users of Shaken Fist, oVirt,
+OpenStack, or any other cloud where the hypervisor is capable of providing SPICE
+consoles over the network.
+
+The SPICE protocol has existed for a long time, and still represents the
+richest and most performant option for remote desktops using Open Source
+technologies. Before Kerbside, consoles were generally provided by a HTML5
+transcoded interface in a web client. Unfortunately, HTML5 interfaces do not
+support many of the more novel features of the SPICE protocol, nor do they
+support high resolution desktops. By avoiding transcoding to a HTML5 client,
+we avoid these problems.
+
+Novel features of SPICE include high resolution desktops, multi-screen desktops,
+USB device passthrough, sound, multiple user connections to a single console,
+adaptive compression, and more.
+
+### Kerbside is Experimental
+
+Kerbside is currently considered experimental. While it works, it has not yet
+seen large scale deployment and it is likely that it will need modifications
+as it is hardened for production use.
+
+### Kerbside is a Proxy, Not a Complete User Interface
+
+Whilst Kerbside presents a simple administrative interface over HTTP and has
+REST APIs for orchestrating consoles, it is not intended as a complete SPICE
+desktop VDI solution. It is intended that Kerbside itself is orchestrated by
+an external system. That is, in order for a desktop to be presented to a user
+the following steps need to occur:
+
+1. The user requests a desktop via an external user interface that we call "the
+   Broker". In Shaken Fist's case the broker is embedded in Shaken Fist itself
+   and is initiated via a Shaken Fist REST API. In the OpenStack case this role
+   is likely performed by Horizon or Skyline, although this is not yet
+   implemented.
+
+2. The cloud boots the instance that runs the desktop. The Broker waits for the
+   instance to be booted.
+
+3. The Broker requests a `.vv` virt-viewer compatible ini file from Kerbside,
+   and delivers that to the requesting user. The configuration file describes a
+   connection to Kerbside, along with short lived access token.
+
+4. The user opens the `.vv` file with a SPICE client such as `remote-viewer`.
+   `remote-viewer` connects to Kerbside.
+
+5. Kerbside uses the access token to determine which instance in the cloud is
+   the requested desktop and initiates a proxied connection to the hypervisor.
+
+6. The user then happily uses their SPICE console, largely unaware of these
+   various steps.
+
+### Connection Flow Diagram
+
+```
++------------------+              +-------------------+              +------------------+
+|                  |              |                   |              |                  |
+|  External Broker |  1. Request  |     Kerbside      |  5. Connect  |   Hypervisor     |
+|  (SF/Horizon)    +------------->|   SPICE Proxy     +------------->|   (QEMU/KVM)     |
+|                  |   .vv file   |                   |   to console |                  |
++--------+---------+              +---------+---------+              +------------------+
+         |                                  ^
+         | 2. Return                        |
+         |    .vv file                      | 4. Connect with
+         v                                  |    access token
++--------+---------+                        |
+|                  |                        |
+|   User's SPICE   +------------------------+
+|   Client         |  3. User opens .vv file
+|  (remote-viewer) |
+|                  |
++------------------+
+```
+
+### Implementation in OpenStack
+
+OpenStack Nova now supports native SPICE direct consoles as of the 2025.1 Epoxy
+release. The
+[Nova specification](https://specs.openstack.org/openstack/nova-specs/specs/2025.1/implemented/libvirt-spice-direct-consoles.html)
+adds a new "spice-direct" console type that enables users to access virtual
+desktops using native SPICE clients like remote-viewer instead of HTML5 proxies.
+
+When users request a SPICE direct console, Nova returns a URL pointing to
+Kerbside with an authentication token. Kerbside validates this token via the
+`/os-console-auth-tokens/` API and establishes the proxied connection to the
+hypervisor. This provides users with a much richer virtual desktop experience
+including support for USB passthrough, audio, and multi-monitor configurations.
+
+Kerbside needs to be deployed as a component of the OpenStack cluster to provide
+a safe mechanism for users to interact with their console. OpenStack is (wisely)
+unwilling to provide direct network connectivity from a client network to TCP
+ports on the hypervisor, and so Kerbside acts as an intermediary to protect
+those hypervisors. There is a sample implementation of Kerbside deployment using
+Kolla-Ansible in the
+[Kerbside Patches repository](https://github.com/shakenfist/kerbside-patches).
+
+### What About Bumblebee?
+
+The folks over at the NECTAR research cloud developed
+[Bumblebee VDI](https://github.com/NeCTAR-RC/bumblebee), which is superficially
+similar to Kerbside in that it provides a mechanism to make it easier to obtain
+a virtual desktop as a user. The Kerbside description above would classify
+Bumblebee as a Broker to our model -- it orchestrates the creation and then
+access to virtual desktops for users. However, Bumblebee exclusively orchestrates
+HTML5 consoles using Apache Guacamole as its HTML5 proxy at the moment, so misses
+out on some of the richer features of SPICE and has the performance implications
+of a HTML5 desktop environment.
+
+## Documentation Index
+
+### Operator Documentation
+
+Guides for deploying and configuring Kerbside:
+
+- [Configuration](configuration.md) - Configuration reference for all Kerbside
+  settings including TLS, Keystone, API, and monitoring options
+
+- [Console Sources](console-sources.md) - Configuring console sources
+  (sources.yaml) for Shaken Fist, oVirt, and OpenStack
+
+- [Database Schema](schema.md) - Database tables, columns, and relationships
+
+### Architecture Documentation
+
+Internal design of the Kerbside proxy:
+
+- [Proxy Architecture](proxy-architecture.md) - Internal architecture including
+  process model, connection state machine, traffic inspection, and worker
+  management
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) - High-level system architecture
+  overview (in project root)
+
+### SPICE Protocol Documentation
+
+Core protocol specifications covering connection handshake, authentication, and
+channel message formats:
+
+- [Protocol Overview](protocol-overview.md) - Introduction to SPICE protocol
+  fundamentals including channel types, message structure, capabilities, and
+  security model
+
+- [Link Protocol](spice-link-protocol.md) - Connection handshake details
+  including SpiceLinkMess/SpiceLinkReply formats, RSA key exchange, and
+  authentication flow
+
+- [Channel Protocols](channel-protocols.md) - Detailed message formats for each
+  SPICE channel:
+  - Main channel - Session control, channel negotiation
+  - Display channel - Screen updates, drawing operations, video streaming
+  - Inputs channel - Keyboard and mouse input
+  - Cursor channel - Cursor shape and position
+  - Playback/Record channels - Audio streaming
+  - Smartcard channel - Smart card redirection
+
+- [Keyboard Scancodes](scancodes.md) - Complete reference for IBM PC XT
+  scancodes used by the inputs channel, including standard keys, extended keys
+  (E0 prefix), and media/browser keys
+
+- [Compression Protocols](compression-protocols.md) - LZ and GLZ image
+  compression formats used by the display channel, including header formats,
+  command encoding, and dictionary-based decompression
+
+- [Capabilities](capabilities.md) - Channel capability negotiation including
+  common, display, audio, and input capabilities with recommended settings
+
+### Device Redirection Protocols
+
+Protocols for redirecting client devices to the virtual machine:
+
+- [USB Redirection](usb-redirection.md) - USB device redirection protocol
+  (usbredir) including all control and data message formats, capability
+  negotiation, and device filter rules
+
+### Guest Agent Protocol
+
+Protocol for advanced guest integration features:
+
+- [VD Agent Protocol](vd-agent-protocol.md) - Guest agent protocol for
+  clipboard sharing, file transfer, display configuration, and volume sync
+
+## Protocol Implementation Status
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| SPICE Link Handshake | Full | Token-based auth extension |
+| Main Channel | Full | Session control, agent passthrough |
+| Display Channel | Full | All drawing ops, video streaming |
+| Inputs Channel | Full | Keyboard, mouse, scancodes |
+| Cursor Channel | Full | Shape, position, trail |
+| Playback Channel | Proxy | Audio passthrough |
+| Record Channel | Proxy | Audio passthrough |
+| Smartcard Channel | Proxy | Passthrough |
+| USB Redirection | Proxy | Passthrough with hello decoding |
+| Port Channel (VMC) | Full | USB redir encapsulation |
+| WebDAV Channel | Proxy | Passthrough |
+| VD Agent | Proxy | Clipboard/file transfer passthrough |
+
+**Full**: Protocol decoded and logged during inspection
+**Proxy**: Traffic forwarded transparently without decoding
+
+## Quick Reference
+
+### Channel Types
+
+| ID | Channel   | Purpose |
+|---:|-----------|---------|
+|  1 | main      | Session control |
+|  2 | display   | Screen updates |
+|  3 | inputs    | Keyboard/mouse |
+|  4 | cursor    | Cursor rendering |
+|  5 | playback  | Audio output |
+|  6 | record    | Audio input |
+|  7 | tunnel    | Obsolete |
+|  8 | smartcard | Smart card |
+|  9 | usbredir  | USB devices |
+| 10 | port      | VMC protocol |
+| 11 | webdav    | File sharing |
+
+### Error Codes
+
+See [Protocol Overview - Error Codes](protocol-overview.md#error-codes) for the
+complete list of SPICE link error codes.
+
+### Common Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+| 0 | AuthSelection | Auth mechanism selection |
+| 1 | AuthSpice | SPICE native auth |
+| 2 | AuthSASL | SASL auth |
+| 3 | MiniHeader | Compact message headers |
+
+## External References
+
+Official SPICE protocol resources:
+
+- [SPICE Protocol Documentation](https://www.spice-space.org/spice-protocol.html)
+- [SPICE Protocol Source](https://gitlab.freedesktop.org/spice/spice-protocol)
+- [SPICE Server Source](https://gitlab.freedesktop.org/spice/spice)
+- [USB Redirection Protocol](https://www.spice-space.org/usbredir.html)
+- [usbredir Source](https://gitlab.freedesktop.org/spice/usbredir)
+- [usbredir Protocol Spec](https://gitlab.freedesktop.org/spice/usbredir/-/blob/main/docs/usb-redirection-protocol.md)
+
+## Contributing
+
+When adding new protocol support or modifying existing implementations:
+
+1. Update the relevant documentation in this directory
+2. Include binary format descriptions with field offsets
+3. Document any deviations from the official SPICE protocol
+4. Add traffic inspection support in `spiceprotocol/packets/`
+5. Update constants in `spiceprotocol/packets/constants.py`
+
+## Document Conventions
+
+Throughout this documentation:
+
+- **Binary formats** use little-endian byte order unless noted otherwise
+- **Offset** values are in bytes from the start of the structure
+- **Size** values are in bytes
+- **uint32**, **uint16**, **uint8** refer to unsigned integers
+- **int32**, **int16**, **int8** refer to signed integers
+- **bytes** refers to raw binary data
+- **string** refers to null-terminated ASCII/UTF-8 text
+- **S->C** means server to client direction
+- **C->S** means client to server direction

--- a/docs/protocol-overview.md
+++ b/docs/protocol-overview.md
@@ -1,0 +1,253 @@
+# SPICE Protocol Overview
+
+This document provides a high-level overview of the SPICE (Simple Protocol for
+Independent Computing Environments) protocol as implemented in Kerbside.
+
+## Introduction
+
+SPICE is a remote desktop protocol developed by Red Hat for virtual machine
+remote console access. It provides high-performance display, input, and device
+redirection capabilities. Kerbside implements a SPICE protocol proxy that sits
+between SPICE clients (such as virt-viewer or remote-viewer) and hypervisors
+running QEMU/KVM with SPICE support.
+
+## Protocol Fundamentals
+
+### Connection Model
+
+SPICE uses a multi-channel architecture where each type of functionality has its
+own dedicated channel:
+
+| Channel Type | ID | Purpose | Kerbside Support |
+|--------------|---:|---------|------------------|
+| main         |  1 | Session control, channel negotiation | Full |
+| display      |  2 | Display updates, video streaming | Full |
+| inputs       |  3 | Keyboard and mouse input | Full |
+| cursor       |  4 | Cursor shape and position | Full |
+| playback     |  5 | Audio playback | Proxy only |
+| record       |  6 | Audio recording | Proxy only |
+| tunnel       |  7 | Obsolete | N/A |
+| smartcard    |  8 | Smart card redirection | Proxy only |
+| usbredir     |  9 | USB redirection | Proxy only |
+| port         | 10 | Port/device redirection (VMC protocol) | Full |
+| webdav       | 11 | WebDAV file sharing | Proxy only |
+
+### Connection Establishment
+
+1. **Main Channel Connection**: The client first establishes a main channel
+   connection, which receives a unique session ID from the server.
+
+2. **Channel Negotiation**: The server sends a list of available channels.
+   The client then opens additional connections for each channel it wants to
+   use, referencing the session ID.
+
+3. **Bidirectional Communication**: Each channel operates as a full-duplex
+   communication path with its own message types.
+
+### Protocol Versioning
+
+SPICE protocol uses major and minor version numbers:
+
+- **Magic**: `REDQ` (0x51444552 little-endian)
+- **Major Version**: 2
+- **Minor Version**: 2
+
+All multi-byte integers use little-endian byte order unless otherwise noted.
+
+## Message Structure
+
+SPICE supports two message header formats: the full `SpiceDataHeader` and the
+compact `SpiceMiniDataHeader`. The mini header is used when both sides advertise
+the `MiniHeader` capability.
+
+### Full Data Header (SpiceDataHeader)
+
+```
++------------------+------------------+------------------+------------------+------------------+
+|      Serial      |   Message Type   |   Message Size   |     Sub List     |  Message Payload |
+|    (8 bytes)     |    (2 bytes)     |    (4 bytes)     |    (4 bytes)     |   (variable)     |
++------------------+------------------+------------------+------------------+------------------+
+```
+
+| Field | Size | Description |
+|-------|------|-------------|
+| serial | UINT64 | Message sequence number, starts at 1, increments per message |
+| type | UINT16 | Message type identifier |
+| size | UINT32 | Payload length in bytes |
+| sub_list | UINT32 | Offset to sub-message list (0 if none) |
+
+### Mini Data Header (SpiceMiniDataHeader)
+
+When the `MiniHeader` capability (bit 3) is negotiated, the compact header is
+used:
+
+```
++------------------+------------------+------------------+
+|   Message Type   |   Message Size   |  Message Payload |
+|    (2 bytes)     |    (4 bytes)     |   (variable)     |
++------------------+------------------+------------------+
+```
+
+| Field | Size | Description |
+|-------|------|-------------|
+| type | UINT16 | Message type identifier |
+| size | UINT32 | Payload length in bytes |
+
+**Note**: Kerbside uses the mini header format, which is the common case for
+modern SPICE implementations.
+
+### Sub-Messages
+
+Messages can contain sub-messages when `sub_list` is non-zero:
+
+```
+SpiceSubMessageList:
+  UINT16 count          - Number of sub-messages
+  UINT32[] offsets      - Offsets to each sub-message
+
+SpiceSubMessage:
+  UINT16 type           - Sub-message type
+  UINT32 size           - Sub-message payload size
+  ...    payload        - Sub-message data
+```
+
+## Capabilities Negotiation
+
+During the handshake, both client and server exchange capability bitmaps.
+Capabilities are stored as 32-bit words, with each bit representing a feature.
+
+### Common Capabilities
+
+| Bit | Capability      | Description |
+|----:|-----------------|-------------|
+|   0 | AuthSelection   | Supports authentication mechanism selection |
+|   1 | AuthSpice       | Supports SPICE native authentication |
+|   2 | AuthSASL        | Supports SASL authentication |
+|   3 | MiniHeader      | Supports mini header format (reduced overhead) |
+
+### Main Channel Capabilities
+
+| Bit | Capability             | Description |
+|----:|------------------------|-------------|
+|   0 | SemiSeamlessMigrate    | Supports semi-seamless VM migration |
+|   1 | NameAndUUID            | Supports VM name and UUID reporting |
+|   2 | AgentConnectedTokens   | Supports agent connection tokens |
+|   3 | SeamlessMigrate        | Supports seamless VM migration |
+
+### Display Channel Capabilities
+
+| Bit | Capability             | Description |
+|----:|------------------------|-------------|
+|   0 | InvalidateList         | Supports invalidate list messages |
+|   1 | StreamReportSupport    | Supports stream reporting |
+|   2 | MultiCodec             | Supports multiple video codecs |
+|   3 | CodecMJPEG             | Supports MJPEG video codec |
+|   4 | CodecVP8               | Supports VP8 video codec |
+|   5 | CodecH264              | Supports H.264 video codec |
+|   6 | A8Surface              | Supports A8 surface format |
+|   7 | StreamReport           | Stream report enabled |
+|   8 | LZ4Compression         | Supports LZ4 image compression |
+|   9 | CodecVP9               | Supports VP9 video codec |
+|  10 | GLScanout              | Supports GL scanout |
+|  11 | CodecH265              | Supports H.265/HEVC video codec |
+
+### Playback Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+|   0 | CELT_0_5_1 | CELT 0.5.1 codec (deprecated) |
+|   1 | Volume     | Volume control support |
+|   2 | Latency    | Latency reporting |
+|   3 | Opus       | Opus audio codec |
+
+### Record Channel Capabilities
+
+| Bit | Capability | Description |
+|----:|------------|-------------|
+|   0 | CELT_0_5_1 | CELT 0.5.1 codec (deprecated) |
+|   1 | Volume     | Volume control support |
+|   2 | Opus       | Opus audio codec |
+
+### Inputs Channel Capabilities
+
+| Bit | Capability   | Description |
+|----:|--------------|-------------|
+|   0 | KeyScancode  | Supports raw keyboard scancodes |
+
+### SPICEVMC Channel Capabilities (Port/USB)
+
+| Bit | Capability       | Description |
+|----:|------------------|-------------|
+|   0 | DataCompression  | Supports compressed VMC data |
+
+## Security
+
+SPICE supports multiple security mechanisms:
+
+1. **TLS/SSL Encryption**: All traffic between client and server can be
+   encrypted using TLS. Kerbside requires TLS for all client connections.
+
+2. **Password Authentication**: Passwords are encrypted using RSA-OAEP with
+   SHA-1 before transmission. The server provides its public key during
+   handshake.
+
+3. **Token-Based Authentication**: Kerbside extends this by using time-limited
+   tokens instead of static passwords, providing an additional security layer.
+
+## Error Codes
+
+The protocol defines standard error codes:
+
+| Code | Name              | Description |
+|-----:|-------------------|-------------|
+|    0 | ok                | Success |
+|    1 | error             | Generic error |
+|    2 | invalid_magic     | Invalid protocol magic number |
+|    3 | invalid_data      | Malformed data received |
+|    4 | version_mismatch  | Incompatible protocol version |
+|    5 | need_secured      | TLS connection required |
+|    6 | need_unsecured    | Non-TLS connection required |
+|    7 | permission_denied | Authentication failed |
+|    8 | bad_connection_id | Invalid session/connection ID |
+|    9 | channel_unavailable | Requested channel not available |
+
+## Common Message Types
+
+Certain message types are shared across all channels:
+
+### Client to Server (Common)
+
+| ID | Message              | Description |
+|---:|----------------------|-------------|
+|  1 | ack_sync             | Acknowledge sync with generation counter |
+|  2 | ack                  | Acknowledge message receipt |
+|  3 | pong                 | Response to ping |
+|  4 | migrate_flush_mark   | Migration marker |
+|  5 | migrate_data         | Migration data transfer |
+|  6 | disconnecting        | Client disconnecting |
+
+### Server to Client (Common)
+
+| ID | Message              | Description |
+|---:|----------------------|-------------|
+|  1 | migrate              | Migration request |
+|  2 | migrate_data         | Migration data transfer |
+|  3 | set_ack              | Configure acknowledgement window |
+|  4 | ping                 | Ping request |
+|  5 | wait_for_channels    | Wait for channel traffic |
+|  6 | disconnecting        | Server disconnecting |
+|  7 | notify               | Notification message |
+
+## External References
+
+- [SPICE Protocol Documentation](https://www.spice-space.org/spice-protocol.html)
+  (incomplete but useful)
+- [SPICE Protocol Source](https://gitlab.freedesktop.org/spice/spice-protocol)
+- [SPICE Server Source](https://gitlab.freedesktop.org/spice/spice)
+- [USB Redirection Protocol](https://www.spice-space.org/usbredir.html)
+
+## Related Documentation
+
+- [Link Protocol](spice-link-protocol.md) - Connection handshake details
+- [Channel Protocols](channel-protocols.md) - Per-channel message formats
+- [USB Redirection](usb-redirection.md) - USB device redirection protocol

--- a/docs/proxy-architecture.md
+++ b/docs/proxy-architecture.md
@@ -1,0 +1,437 @@
+# Kerbside Proxy Architecture
+
+This document provides a detailed technical description of Kerbside's proxy
+architecture, including the connection state machine, process model, and traffic
+handling.
+
+## Process Architecture
+
+Kerbside uses a multiprocess architecture for scalability and isolation:
+
+```
++---------------------------+
+|    kerbside-daemon        |  Main daemon process
+|    (main.py)              |  - Spawns proxy subprocess
+|                           |  - Runs maintenance loop
++-------------+-------------+
+              |
+              | Subprocess
+              v
++---------------------------+
+|    kerbside-proxy         |  Proxy manager process
+|    (proxy.py:run)         |  - Accepts connections
+|                           |  - Spawns workers
++-------------+-------------+
+              |
+              | multiprocessing.Process
+              v
++---------------------------+
+|    kerbside-secure-*      |  Worker processes (one per connection)
+|    (SpiceTLSSession)      |  - Handles single SPICE channel
+|                           |  - Bidirectional proxy
++---------------------------+
+```
+
+### Benefits of Multiprocess Architecture
+
+1. **Isolation**: Each connection runs in its own process, preventing one
+   misbehaving connection from affecting others.
+
+2. **Resource Management**: Workers can be killed individually if they become
+   unresponsive or consume excessive resources.
+
+3. **Simplicity**: No complex threading or async I/O required; each worker uses
+   simple blocking I/O with `select()`.
+
+4. **Observability**: Process names reflect connection state, making monitoring
+   easier (e.g., `kerbside-secure-abc123-display-0`).
+
+## Connection Listener
+
+The `SpiceListener` class manages incoming connections:
+
+```python
+class SpiceListener:
+    def __init__(self, address, port, tls_port):
+        # Insecure port (5901) - redirects to TLS
+        self.unsecured = socket.socket(...)
+        self.unsecured.bind((address, port))
+
+        # Secure port (5900) - TLS-wrapped connections
+        self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self.ssl_context.load_cert_chain(cert_path, key_path)
+        self.secured = socket.socket(...)
+        self.secured.bind((address, tls_port))
+```
+
+### TLS Configuration
+
+- Server certificate and key loaded from configured paths
+- CA certificate loaded for client verification (optional)
+- Default verify paths configured for system CAs
+
+## Connection State Machine
+
+### Insecure Connection Flow (SpiceSession)
+
+Connections to the insecure port (5901) follow a simple flow:
+
+```
+     Accept Connection
+            |
+            v
+    +---------------+
+    | Receive Data  |
+    +-------+-------+
+            |
+            v
+    +---------------+
+    | Parse Client  |
+    | SpiceLinkMess |
+    +-------+-------+
+            |
+            v
+    +---------------+
+    | Send Reply    |
+    | need_secured  |
+    +-------+-------+
+            |
+            v
+    +---------------+
+    | Close         |
+    +---------------+
+```
+
+This redirects clients to use TLS on port 5900.
+
+### Secure Connection Flow (SpiceTLSSession)
+
+TLS connections follow a more complex state machine:
+
+```
+     Accept TLS Connection
+            |
+            v
+    +-------------------+
+    | ClientSpiceLinkMess|  Parse client hello, send server hello
+    +--------+----------+
+             |
+             v
+    +-------------------+
+    | ClientPassword    |  Decrypt token, validate, connect to hypervisor
+    +--------+----------+
+             |
+             v
+    +-------------------+
+    | ClientProxy       |  Bidirectional traffic relay
+    | ServerProxy       |
+    +-------------------+
+```
+
+### State Handlers
+
+Each state is implemented as a method that returns the number of bytes consumed:
+
+```python
+class SpiceTLSSession:
+    def __init__(self, ...):
+        self.client_next_packet = self.ClientSpiceLinkMess  # Initial state
+        self.server_next_packet = None
+
+    def ClientSpiceLinkMess(self, buffered):
+        # Parse client hello
+        # Generate RSA keypair
+        # Send server hello with public key
+        self.client_next_packet = self.ClientPassword
+        return bytes_consumed
+
+    def ClientPassword(self, buffered):
+        # Decrypt token
+        # Validate against database
+        # Connect to hypervisor
+        self.client_next_packet = self.ClientProxy
+        self.server_next_packet = self.ServerProxy
+        return bytes_consumed
+
+    def ClientProxy(self, buffered):
+        # Parse and forward client traffic to server
+        return bytes_consumed
+
+    def ServerProxy(self, buffered):
+        # Parse and forward server traffic to client
+        return bytes_consumed
+```
+
+## Main Processing Loop
+
+The main processing loop uses non-blocking I/O with `select()`:
+
+```python
+def run(self):
+    client_buffered = bytearray()
+    server_buffered = bytearray()
+
+    while True:
+        sockets = [self.client_conn]
+        if self.server_conn:
+            sockets.append(self.server_conn)
+
+        # Wait for data (0.2 second timeout)
+        readable, _, errors = select.select(sockets, [], sockets, 0.2)
+
+        # Read available data
+        for r in readable:
+            if r == self.client_conn:
+                client_buffered += self.client_conn.recv(1024000)
+            elif r == self.server_conn:
+                server_buffered += self.server_conn.recv(1024000)
+
+        # Process buffered data
+        if client_buffered:
+            consumed = self.client_next_packet(client_buffered)
+            while consumed > 0:
+                client_buffered = client_buffered[consumed:]
+                consumed = self.client_next_packet(client_buffered)
+
+        if self.server_next_packet and server_buffered:
+            consumed = self.server_next_packet(server_buffered)
+            while consumed > 0:
+                server_buffered = server_buffered[consumed:]
+                consumed = self.server_next_packet(server_buffered)
+```
+
+### Why 0.2 Second Timeout?
+
+The short timeout ensures responsive handling even when:
+- State transitions occur that enable new packet processing
+- One socket becomes readable while processing the other
+- Clean shutdown needs to occur
+
+## Packet Parsing Pattern
+
+All packet parsers follow a consistent pattern:
+
+```python
+def parse_packet(buffered):
+    # Check minimum header size
+    if len(buffered) < HEADER_SIZE:
+        return 0  # Need more data
+
+    # Parse header
+    message_type, message_size = struct.unpack_from('<HI', buffered)
+
+    # Check if complete message is available
+    if len(buffered) < HEADER_SIZE + message_size:
+        return 0  # Need more data
+
+    # Process message
+    # ...
+
+    # Return bytes consumed
+    return HEADER_SIZE + message_size
+```
+
+This pattern enables:
+- Partial packet handling (wait for more data)
+- Multiple packets in one read (process in loop)
+- Clean separation of concerns
+
+## Traffic Inspection
+
+Kerbside can optionally inspect and log all traffic:
+
+### Inspector Architecture
+
+```python
+class InspectableTraffic:
+    def configure_inspection(self, source, uuid, session_id, channel):
+        if config.TRAFFIC_INSPECTION:
+            self.logfile = open(...)
+
+    def emit_entry(self, entry):
+        if config.TRAFFIC_INSPECTION:
+            self.logfile.write(f'{timestamp} {entry}\n')
+```
+
+### Channel-Specific Inspectors
+
+Each channel type has dedicated inspectors:
+
+| Channel | Client Inspector | Server Inspector |
+|---------|------------------|------------------|
+| main    | ClientMainPacket | ServerMainPacket |
+| display | ClientDisplayPacket | ServerDisplayPacket |
+| inputs  | ClientInputsPacket | ServerInputsPacket |
+| cursor  | ClientCursorPacket | ServerCursorPacket |
+| port    | ClientPortPacket | ServerPortPacket |
+
+### Intimate Logging
+
+With `TRAFFIC_INSPECTION_INTIMATE` enabled, detailed data is logged:
+- Keystrokes and scancodes
+- Mouse coordinates and button states
+- Image frame data
+
+This creates audit trails but should be used carefully due to privacy
+implications.
+
+## ACK Handling for Inserted Packets
+
+When traffic inspection modifies packets (e.g., adding border frames),
+the proxy must handle acknowledgements correctly:
+
+```python
+def ClientProxy(self, buffered):
+    pt = self.client_parser(buffered)
+
+    if pt.inserted_packets > 0:
+        # We inserted packets that server will ACK
+        self.server_ignore_acks += pt.inserted_packets
+
+    if pt.packet_is_ack and self.client_ignore_acks > 0:
+        # This ACK is for a packet we inserted, don't forward
+        self.client_ignore_acks -= 1
+    else:
+        self.server_conn.sendall(pt.data_to_send)
+```
+
+## Worker Management
+
+The proxy manager monitors and manages worker processes:
+
+### Worker Tracking
+
+```python
+workers = []
+
+for conn, client_host, client_port, secured in listen.accept():
+    session = SpiceTLSSession(conn, client_host, client_port)
+    p = multiprocessing.Process(target=session.run, ...)
+    p.start()
+    workers.append(p)
+```
+
+### Worker Cleanup
+
+Every second, the proxy manager:
+
+1. **Identifies stray processes**: Workers older than 5 seconds without
+   database channel records
+2. **Terminates strays**: Sends SIGKILL to unregistered workers
+3. **Reaps terminated workers**: Joins completed processes and removes
+   database records
+
+```python
+# Find strays
+for child in psutil.Process(os.getpid()).children():
+    if child.pid not in channel_pids:
+        if time.time() - child.create_time() > 5:
+            os.kill(child.pid, signal.SIGKILL)
+
+# Reap terminated
+for p in workers:
+    if not p.is_alive():
+        p.join(1)
+        db.remove_proxy_channel(config.NODE_NAME, p.pid)
+```
+
+## Database State
+
+Worker processes register their state in the database:
+
+### Channel Info Recording
+
+```python
+db.record_channel_info(
+    node_name,
+    pid,
+    client_ip=...,
+    client_port=...,
+    connection_id=...,
+    channel_type=...,
+    channel_id=...,
+    session_id=...
+)
+```
+
+This enables:
+- Cross-process monitoring
+- Admin UI session display
+- Cleanup of orphaned records
+
+## Prometheus Metrics
+
+Workers report metrics via a shared queue:
+
+```python
+# In worker
+self.prometheus_updates.put(('bytes_proxied', labels, byte_count))
+
+# In manager
+while True:
+    name, labels, value = prometheus_updates.get(block=False)
+    if name == 'bytes_proxied':
+        bytes_proxied.labels(**labels).inc(value)
+```
+
+### Exported Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| workers | Gauge | - | Number of active workers |
+| bytes_proxied | Counter | type, session_id | Bytes transferred |
+| proxy_time | Counter | type, session_id | Processing time |
+
+## Error Handling
+
+### Connection Errors
+
+| Error | Handling |
+|-------|----------|
+| BadMagic/BadMajor/BadMinor | Terminate connection |
+| HandshakeFailed | Terminate connection |
+| ConnectionRefused | Log, terminate |
+| BrokenPipeError | Log, cleanup sockets |
+| ConnectionResetError | Log, cleanup sockets |
+
+### SSL Errors
+
+SSL read errors are handled gracefully:
+
+```python
+try:
+    d = self.client_conn.recv(1024000)
+except ssl.SSLWantReadError:
+    # SSL layer has no data, continue loop
+    pass
+```
+
+## Security Considerations
+
+### Token Validation
+
+All connections must present valid tokens:
+- Tokens are time-limited (configurable expiry)
+- Tokens are single-use (prevent replay attacks)
+- Invalid tokens result in immediate disconnection
+
+### Audit Logging
+
+All significant events are logged:
+- Channel creation
+- Hypervisor connection success/failure
+- Token validation results
+- Traffic inspection events (if enabled)
+
+### Process Isolation
+
+Each connection runs in its own process:
+- Memory isolation between connections
+- Independent crash handling
+- Resource limits can be applied per-process
+
+## Related Documentation
+
+- [Protocol Overview](protocol-overview.md) - SPICE protocol introduction
+- [Link Protocol](spice-link-protocol.md) - Connection handshake details
+- [Channel Protocols](channel-protocols.md) - Per-channel message formats

--- a/docs/scancodes.md
+++ b/docs/scancodes.md
@@ -1,0 +1,297 @@
+# Keyboard Scancodes
+
+This document provides a reference for the keyboard scancodes used by the SPICE
+protocol's inputs channel. SPICE uses IBM PC XT-compatible scancodes (Set 1).
+
+## Scancode Format
+
+SPICE supports two scancode formats:
+
+### Simple Scancodes (key_down/key_up messages)
+
+The `key_down` (ID 101) and `key_up` (ID 102) messages use a 32-bit scancode
+field. For standard keys, only the low byte is used.
+
+### Raw Scancodes (key_scancode message)
+
+The `key_scancode` (ID 104) message sends raw XT scancodes as a byte array.
+This format is more efficient for extended keys and supports:
+
+- **Key press**: Scancode byte as-is
+- **Key release**: Scancode byte OR'd with 0x80 (high bit set)
+- **Extended keys**: Prefixed with 0xE0 byte
+
+For example:
+- Press 'A': `[0x1E]`
+- Release 'A': `[0x9E]` (0x1E | 0x80)
+- Press Right Ctrl: `[0xE0, 0x1D]`
+- Release Right Ctrl: `[0xE0, 0x9D]`
+
+## Standard Scancodes
+
+### Main Keyboard - Row 1 (Function Keys)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Escape | 1 | 0x01 |
+| F1 | 59 | 0x3B |
+| F2 | 60 | 0x3C |
+| F3 | 61 | 0x3D |
+| F4 | 62 | 0x3E |
+| F5 | 63 | 0x3F |
+| F6 | 64 | 0x40 |
+| F7 | 65 | 0x41 |
+| F8 | 66 | 0x42 |
+| F9 | 67 | 0x43 |
+| F10 | 68 | 0x44 |
+| F11 | 87 | 0x57 |
+| F12 | 88 | 0x58 |
+
+### Main Keyboard - Row 2 (Number Row)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| ` (Backquote) | 41 | 0x29 |
+| 1 | 2 | 0x02 |
+| 2 | 3 | 0x03 |
+| 3 | 4 | 0x04 |
+| 4 | 5 | 0x05 |
+| 5 | 6 | 0x06 |
+| 6 | 7 | 0x07 |
+| 7 | 8 | 0x08 |
+| 8 | 9 | 0x09 |
+| 9 | 10 | 0x0A |
+| 0 | 11 | 0x0B |
+| - (Minus) | 12 | 0x0C |
+| = (Equal) | 13 | 0x0D |
+| Backspace | 14 | 0x0E |
+
+### Main Keyboard - Row 3 (QWERTY)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Tab | 15 | 0x0F |
+| Q | 16 | 0x10 |
+| W | 17 | 0x11 |
+| E | 18 | 0x12 |
+| R | 19 | 0x13 |
+| T | 20 | 0x14 |
+| Y | 21 | 0x15 |
+| U | 22 | 0x16 |
+| I | 23 | 0x17 |
+| O | 24 | 0x18 |
+| P | 25 | 0x19 |
+| [ (BracketLeft) | 26 | 0x1A |
+| ] (BracketRight) | 27 | 0x1B |
+| \\ (Backslash) | 43 | 0x2B |
+
+### Main Keyboard - Row 4 (ASDF)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Caps Lock | 58 | 0x3A |
+| A | 30 | 0x1E |
+| S | 31 | 0x1F |
+| D | 32 | 0x20 |
+| F | 33 | 0x21 |
+| G | 34 | 0x22 |
+| H | 35 | 0x23 |
+| J | 36 | 0x24 |
+| K | 37 | 0x25 |
+| L | 38 | 0x26 |
+| ; (Semicolon) | 39 | 0x27 |
+| ' (Quote) | 40 | 0x28 |
+| Enter | 28 | 0x1C |
+
+### Main Keyboard - Row 5 (ZXCV)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Left Shift | 42 | 0x2A |
+| Z | 44 | 0x2C |
+| X | 45 | 0x2D |
+| C | 46 | 0x2E |
+| V | 47 | 0x2F |
+| B | 48 | 0x30 |
+| N | 49 | 0x31 |
+| M | 50 | 0x32 |
+| , (Comma) | 51 | 0x33 |
+| . (Period) | 52 | 0x34 |
+| / (Slash) | 53 | 0x35 |
+| Right Shift | 54 | 0x36 |
+
+### Main Keyboard - Row 6 (Bottom)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Left Ctrl | 29 | 0x1D |
+| Left Alt | 56 | 0x38 |
+| Space | 57 | 0x39 |
+
+### Numeric Keypad
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Numpad 7 (Home) | 71 | 0x47 |
+| Numpad 8 (Up) | 72 | 0x48 |
+| Numpad 9 (PgUp) | 73 | 0x49 |
+| Numpad - | 74 | 0x4A |
+| Numpad 4 (Left) | 75 | 0x4B |
+| Numpad 5 | 76 | 0x4C |
+| Numpad 6 (Right) | 77 | 0x4D |
+| Numpad + | 78 | 0x4E |
+| Numpad 1 (End) | 79 | 0x4F |
+| Numpad 2 (Down) | 80 | 0x50 |
+| Numpad 3 (PgDn) | 81 | 0x51 |
+| Numpad 0 (Ins) | 82 | 0x52 |
+| Numpad . (Del) | 83 | 0x53 |
+| Numpad * | 55 | 0x37 |
+| Numpad = | 89 | 0x59 |
+| Numpad , | 126 | 0x7E |
+
+### Lock Keys
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| Caps Lock | 58 | 0x3A |
+| Scroll Lock | 70 | 0x46 |
+| Pause | 69 | 0x45 |
+
+### Extended Function Keys (F13-F24)
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| F13 | 100 | 0x64 |
+| F14 | 101 | 0x65 |
+| F15 | 102 | 0x66 |
+| F16 | 103 | 0x67 |
+| F17 | 104 | 0x68 |
+| F18 | 105 | 0x69 |
+| F19 | 106 | 0x6A |
+| F20 | 107 | 0x6B |
+| F21 | 108 | 0x6C |
+| F22 | 109 | 0x6D |
+| F23 | 110 | 0x6E |
+| F24 | 118 | 0x76 |
+
+### International Keys
+
+| Key | Scancode | Hex |
+|-----|----------|-----|
+| IntlBackslash | 86 | 0x56 |
+| IntlRo | 115 | 0x73 |
+| IntlYen | 125 | 0x7D |
+| KanaMode | 112 | 0x70 |
+| Convert | 121 | 0x79 |
+| NonConvert | 123 | 0x7B |
+
+## Extended Scancodes (E0 Prefix)
+
+Extended keys require a 0xE0 prefix byte. When using the `key_scancode` message,
+send `[0xE0, scancode]` for press and `[0xE0, scancode | 0x80]` for release.
+
+When using `key_down`/`key_up` messages, the scancode is encoded as:
+`0xE0 | (scancode << 8)`
+
+### Navigation Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Insert | 0x52 | E0 52 |
+| Delete | 0x53 | E0 53 |
+| Home | 0x47 | E0 47 |
+| End | 0x4F | E0 4F |
+| Page Up | 0x49 | E0 49 |
+| Page Down | 0x51 | E0 51 |
+
+### Arrow Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Up Arrow | 0x48 | E0 48 |
+| Down Arrow | 0x50 | E0 50 |
+| Left Arrow | 0x4B | E0 4B |
+| Right Arrow | 0x4D | E0 4D |
+
+### Right-Side Modifier Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Right Ctrl | 0x1D | E0 1D |
+| Right Alt | 0x38 | E0 38 |
+| Left Meta (Windows) | 0x5B | E0 5B |
+| Right Meta (Windows) | 0x5C | E0 5C |
+| Context Menu | 0x5D | E0 5D |
+
+### Numpad Extended Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Numpad Enter | 0x1C | E0 1C |
+| Numpad / | 0x35 | E0 35 |
+| Num Lock | 0x45 | E0 45 |
+| Pause | 0x46 | E0 46 |
+| Print Screen | 0x37 | E0 37 |
+
+### Media Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Volume Mute | 0x20 | E0 20 |
+| Volume Down | 0x2E | E0 2E |
+| Volume Up | 0x30 | E0 30 |
+| Media Play/Pause | 0x22 | E0 22 |
+| Media Stop | 0x24 | E0 24 |
+| Media Previous | 0x10 | E0 10 |
+| Media Next | 0x19 | E0 19 |
+| Media Select | 0x6D | E0 6D |
+
+### Browser Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Browser Home | 0x32 | E0 32 |
+| Browser Back | 0x6A | E0 6A |
+| Browser Forward | 0x69 | E0 69 |
+| Browser Refresh | 0x67 | E0 67 |
+| Browser Stop | 0x68 | E0 68 |
+| Browser Search | 0x65 | E0 65 |
+| Browser Favorites | 0x66 | E0 66 |
+
+### Application Launch Keys
+
+| Key | Extended Code | Bytes (Press) |
+|-----|---------------|---------------|
+| Launch App 1 (My Computer) | 0x6B | E0 6B |
+| Launch App 2 (Calculator) | 0x21 | E0 21 |
+| Launch Mail | 0x6C | E0 6C |
+| Power | 0x5E | E0 5E |
+
+## Example: Typing "Hello"
+
+Using `key_scancode` messages:
+
+```
+H press:   [0x2A, 0x23]     (Shift down, H down)
+H release: [0xA3, 0xAA]     (H up, Shift up)
+e press:   [0x12]           (E down)
+e release: [0x92]           (E up)
+l press:   [0x26]           (L down)
+l release: [0xA6]           (L up)
+l press:   [0x26]           (L down)
+l release: [0xA6]           (L up)
+o press:   [0x18]           (O down)
+o release: [0x98]           (O up)
+```
+
+## References
+
+- [MDN Keyboard Event Code Values](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values)
+- [spice-html5 scancode mapping](https://gitlab.freedesktop.org/nicholasbishop/nicholasbishop-spice-html5/-/blob/main/src/code_to_scancode.js)
+- [Inputs Channel Protocol](channel-protocols.md#inputs-channel-type-3)
+
+## Related Documentation
+
+- [Channel Protocols](channel-protocols.md) - Inputs channel message formats
+- [Capabilities](capabilities.md) - KeyScancode capability negotiation
+- [Protocol Overview](protocol-overview.md) - High-level SPICE protocol

--- a/docs/schema.html
+++ b/docs/schema.html
@@ -12,13 +12,13 @@
           string seen_by
           boolean errored
           string url
-          string ca_cert
+          text ca_cert
           string username
           string password
           string project_name "OpenStack only"
           string user_domain_id "OpenStack only"
           string project_domain_id "OpenStack only"
-          string flavor "OpenStack only"
+          boolean deleted
       }
 
       sources ||--o{ consoles : "sources provide consoles"
@@ -43,7 +43,7 @@
           string uuid FK
           string source FK
           integer created "epoch seconds"
-          integer expired "epoch seconds"
+          integer expires "epoch seconds"
       }
 
       consoletokens ||--o{ proxychannels: "consoletokens authenticate proxychannels"
@@ -65,10 +65,10 @@
           string uuid PK "No FK to avoid cascading delete"
           string session_id "No FK to avoid cascading delete"
           string channel
-          timestamp timestamp PK
+          datetime timestamp PK "microsecond precision"
           string node
-          integer pid
-          string message
+          string pid
+          text message
       }
     </pre>
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,158 @@
+# Database Schema
+
+This document describes the Kerbside MySQL/MariaDB database schema.
+
+## Entity Relationship Diagram
+
+```
++------------------+          +------------------+
+|     sources      |          |     consoles     |
++------------------+          +------------------+
+| name (PK)        |---+      | uuid (PK)        |
+| type             |   |      | source (FK)      |------+
+| last_seen        |   +----->| discovered       |      |
+| seen_by          |          | hypervisor       |      |
+| errored          |          | hypervisor_ip    |      |
+| url              |          | insecure_port    |      |
+| ca_cert          |          | secure_port      |      |
+| username         |          | name             |      |
+| password         |          | host_subject     |      |
+| project_name     |          | ticket           |      |
+| user_domain_id   |          +------------------+      |
+| project_domain_id|                 |                  |
+| deleted          |                 |                  |
++------------------+                 |                  |
+        |                            |                  |
+        |    +------------------+    |                  |
+        |    |  consoletokens   |    |                  |
+        |    +------------------+    |                  |
+        +--->| token (PK)       |<---+                  |
+             | session_id       |                       |
+             | uuid (FK)        |                       |
+             | source (FK)      |                       |
+             | created          |                       |
+             | expires          |                       |
+             +------------------+                       |
+                    |                                   |
+                    |                                   |
+                    v                                   |
+          +------------------+          +------------------+
+          |  proxychannels   |          |   auditevents    |
+          +------------------+          +------------------+
+          | node (PK)        |          | source (PK)      |
+          | pid (PK)         |          | uuid (PK)        |
+          | created          |          | session_id       |
+          | client_ip        |          | channel          |
+          | client_port      |          | timestamp (PK)   |
+          | connection_id    |          | node             |
+          | channel_type     |          | pid              |
+          | channel_id       |          | message          |
+          | session_id (FK)  |          +------------------+
+          +------------------+                  ^
+                                                |
+                                                +----------+
+```
+
+## Table Descriptions
+
+### sources
+
+Console sources (cloud platforms) that provide virtual machines.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| name | string | Primary key, source identifier |
+| type | string | Source type: `shakenfist`, `ovirt`, or `openstack` |
+| last_seen | datetime | Last successful poll time |
+| seen_by | string | Node that last polled this source |
+| errored | boolean | Whether the source is in error state |
+| url | string | API URL for the source |
+| ca_cert | text | CA certificate for TLS validation |
+| username | string | Authentication username |
+| password | string | Authentication password/API key |
+| project_name | string | OpenStack project name (OpenStack only) |
+| user_domain_id | string | OpenStack user domain (OpenStack only) |
+| project_domain_id | string | OpenStack project domain (OpenStack only) |
+| deleted | boolean | Soft delete flag |
+
+### consoles
+
+Virtual machine consoles discovered from sources.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| uuid | string | Primary key, VM UUID |
+| source | string | Foreign key to sources.name |
+| discovered | datetime | When the console was first discovered |
+| hypervisor | string | Hypervisor hostname |
+| hypervisor_ip | string | Hypervisor IP address |
+| insecure_port | integer | Non-TLS SPICE port |
+| secure_port | integer | TLS SPICE port |
+| name | string | VM display name |
+| host_subject | string | Expected TLS certificate subject |
+| ticket | string | SPICE ticket for authentication |
+
+### consoletokens
+
+Time-limited access tokens for console connections.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| token | string | Primary key, 48-character access token |
+| session_id | string | 12-character session identifier |
+| uuid | string | Foreign key to consoles.uuid |
+| source | string | Foreign key to sources.name |
+| created | integer | Token creation time (epoch seconds) |
+| expires | integer | Token expiration time (epoch seconds) |
+
+### proxychannels
+
+Active SPICE channel connections being proxied.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| node | string | Primary key part, proxy node hostname |
+| pid | string | Primary key part, worker process ID |
+| created | datetime | Connection establishment time |
+| client_ip | string | Client IP address |
+| client_port | integer | Client source port |
+| connection_id | integer | SPICE connection ID |
+| channel_type | string | Channel type name (main, display, etc.) |
+| channel_id | integer | Channel instance ID |
+| session_id | string | Foreign key to consoletokens.session_id |
+
+### auditevents
+
+Audit log for console access and protocol events.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| source | string | Primary key part, source name (no FK to avoid cascade) |
+| uuid | string | Primary key part, console UUID (no FK to avoid cascade) |
+| session_id | string | Session identifier (no FK to avoid cascade) |
+| channel | string | Channel type or "session" for session events |
+| timestamp | datetime | Event time with microsecond precision (PK part) |
+| node | string | Proxy node that recorded the event |
+| pid | string | Worker process ID |
+| message | text | Event description |
+
+## Relationships
+
+- **sources → consoles**: One source provides many consoles
+- **sources → consoletokens**: Tokens reference a source for validation
+- **consoles → consoletokens**: Tokens grant access to a specific console
+- **consoletokens → proxychannels**: Active channels reference their auth token
+- **consoles → auditevents**: Audit events record console access (no FK to
+  preserve audit history when consoles are deleted)
+
+## Notes
+
+- The `auditevents` table intentionally avoids foreign key constraints to
+  preserve audit history even when sources or consoles are deleted.
+- Timestamps in `consoletokens` use epoch seconds for easy expiration checks.
+- The `proxychannels` table is used for connection tracking and cleanup.
+
+## Related Documentation
+
+- [Configuration](configuration.md) - Database connection settings
+- [Console Sources](console-sources.md) - Source configuration

--- a/docs/spice-link-protocol.md
+++ b/docs/spice-link-protocol.md
@@ -1,0 +1,307 @@
+# SPICE Link Protocol
+
+This document describes the SPICE link protocol used to establish connections
+and authenticate between clients and servers. In Kerbside, this protocol is
+implemented in `spiceprotocol/packets/linkmessages.py` and
+`spiceprotocol/packets/authentication.py`.
+
+## Connection Handshake Overview
+
+The SPICE connection handshake follows this sequence:
+
+```
+    Client                                          Server
+      |                                               |
+      |  1. SpiceLinkMess (client hello)              |
+      |---------------------------------------------->|
+      |                                               |
+      |  2. SpiceLinkReply (server hello + pubkey)    |
+      |<----------------------------------------------|
+      |                                               |
+      |  3. ClientAuthPacket (encrypted password)     |
+      |---------------------------------------------->|
+      |                                               |
+      |  4. ServerAuthPacket (result code)            |
+      |<----------------------------------------------|
+      |                                               |
+      |  5. Bidirectional channel communication       |
+      |<--------------------------------------------->|
+```
+
+## SpiceLinkMess (Client Hello)
+
+The client initiates the connection by sending a `SpiceLinkMess` packet:
+
+### Binary Format
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     bytes   magic (REDQ = 0x51444552)
+4       4     uint32  major_version
+8       4     uint32  minor_version
+12      4     uint32  size (bytes following this field)
+16      4     uint32  connection_id
+20      1     uint8   channel_type
+21      1     uint8   channel_id
+22      4     uint32  num_common_caps
+26      4     uint32  num_channel_caps
+30      4     uint32  caps_offset
+34+     var   uint32  capabilities (variable length)
+```
+
+### Field Details
+
+**magic** (4 bytes)
+: Protocol magic number. Must be `REDQ` (0x51444552 little-endian).
+
+**major_version** (4 bytes)
+: Protocol major version. Must be 2.
+
+**minor_version** (4 bytes)
+: Protocol minor version. Must be 2.
+
+**size** (4 bytes)
+: Number of bytes following this field to the end of the message.
+
+**connection_id** (4 bytes)
+: For main channel connections (channel_type=1), this is set to 0. The server
+  will allocate a new session ID. For other channels, this contains the session
+  ID returned by the main channel connection.
+
+**channel_type** (1 byte)
+: The type of channel being requested:
+  - 1 = main
+  - 2 = display
+  - 3 = inputs
+  - 4 = cursor
+  - 5 = playback
+  - 6 = record
+  - 8 = usbredir
+  - 9 = port
+  - 10 = webdav
+
+**channel_id** (1 byte)
+: Channel instance ID. Used when multiple channels of the same type exist.
+
+**num_common_caps** (4 bytes)
+: Number of 32-bit words of common capabilities.
+
+**num_channel_caps** (4 bytes)
+: Number of 32-bit words of channel-specific capabilities.
+
+**caps_offset** (4 bytes)
+: Byte offset from the `connection_id` field to the start of the capabilities
+  vector.
+
+**capabilities** (variable)
+: Capability bitmaps. Common capabilities followed by channel capabilities.
+
+## SpiceLinkReply (Server Hello)
+
+The server responds with a `SpiceLinkReply` packet:
+
+### Binary Format
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     bytes   magic (REDQ = 0x51444552)
+4       4     uint32  major_version
+8       4     uint32  minor_version
+12      4     uint32  size (bytes following this field)
+16      4     uint32  error
+20      162   bytes   pubkey (RSA public key in DER format)
+182     4     uint32  num_common_caps
+186     4     uint32  num_channel_caps
+190     4     uint32  caps_offset
+194+    var   uint32  capabilities (variable length)
+```
+
+### Field Details
+
+**error** (4 bytes)
+: Error code. 0 indicates success. See
+  [Protocol Overview - Error Codes](protocol-overview.md#error-codes) for the
+  complete list.
+
+**pubkey** (162 bytes)
+: RSA public key in DER (SubjectPublicKeyInfo) format. Used by the client to
+  encrypt the password. Kerbside generates a unique 1024-bit RSA key pair for
+  each connection.
+
+## Client Authentication Packet
+
+After receiving the server hello, the client sends an authentication packet:
+
+### Binary Format
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  mechanism
+4       128   bytes   encrypted_password
+```
+
+### Field Details
+
+**mechanism** (4 bytes)
+: Authentication mechanism. Must be 1 for SPICE native authentication
+  (AuthSpice).
+
+**encrypted_password** (128 bytes)
+: Password encrypted with RSA-OAEP using SHA-1 for both the mask generation
+  function (MGF1) and the hash algorithm. The plaintext password must be
+  null-terminated before encryption.
+
+### Encryption Details
+
+The password encryption uses:
+- Algorithm: RSA-OAEP
+- Mask Generation Function: MGF1 with SHA-1
+- Hash Algorithm: SHA-1
+- Key Size: 1024 bits (produces 128-byte ciphertext)
+
+Python example (using cryptography library):
+
+```python
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import hashes
+
+encrypted_password = public_key.encrypt(
+    password.encode() + b'\x00',  # Null-terminate
+    padding.OAEP(
+        mgf=padding.MGF1(algorithm=hashes.SHA1()),
+        algorithm=hashes.SHA1(),
+        label=None
+    )
+)
+```
+
+## Server Authentication Response
+
+The server responds with a simple result code:
+
+### Binary Format
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  error
+```
+
+### Field Details
+
+**error** (4 bytes)
+: Error code. 0 indicates successful authentication. Non-zero indicates failure
+  (typically `permission_denied` = 7).
+
+## Kerbside Token Authentication
+
+Kerbside extends the standard SPICE authentication by using time-limited tokens
+instead of static VM passwords:
+
+1. **Token Generation**: The API generates a 48-character alphanumeric token
+   with an associated 12-character session ID.
+
+2. **Token Embedding**: The token is embedded in the virt-viewer configuration
+   file as the "password" field.
+
+3. **Token Validation**: When Kerbside receives the encrypted password, it
+   decrypts it and validates it against the token database, checking:
+   - Token existence
+   - Token expiry time
+   - One-time use (token is invalidated after use)
+
+4. **Console Lookup**: Valid tokens are mapped to specific VM consoles,
+   allowing Kerbside to establish the correct backend connection.
+
+## TLS/SSL Requirements
+
+Kerbside enforces TLS for all client connections:
+
+- **Secure Port (5900)**: TLS-wrapped connections are accepted and processed.
+- **Insecure Port (5901)**: Connections receive a `need_secured` error response
+  redirecting them to the TLS port.
+
+## Connection State Machine
+
+Kerbside's proxy implements the following state machine for TLS connections:
+
+```
++-------------------+
+|  ClientSpiceLinkMess  |  <-- Initial state
++---------+---------+
+          |
+          | Parse client hello, generate RSA keypair,
+          | send server hello with public key
+          v
++-------------------+
+|   ClientPassword   |
++---------+---------+
+          |
+          | Decrypt token, validate, lookup console,
+          | connect to hypervisor, send auth result
+          v
++-------------------+
+|    ClientProxy     |  <-- Bidirectional relay mode
+|    ServerProxy     |
++-------------------+
+```
+
+## Error Handling
+
+### Protocol Errors
+
+| Error | Handling |
+|-------|----------|
+| BadMagic | Connection terminated immediately |
+| BadMajor | Connection terminated immediately |
+| BadMinor | Connection terminated immediately |
+| HandshakeFailed | Connection terminated |
+
+### Authentication Errors
+
+| Condition | Response |
+|-----------|----------|
+| Invalid token | Connection declined, logged |
+| Expired token | Connection declined, logged |
+| Unknown source | Connection declined, logged |
+| Unknown console | Connection declined, logged |
+| Hypervisor unreachable | Connection refused, logged |
+
+## Implementation Notes
+
+### RSA Key Generation
+
+Kerbside generates a fresh RSA key pair for each connection to ensure forward
+secrecy:
+
+```python
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+private_key = rsa.generate_private_key(
+    public_exponent=65537,
+    key_size=1024
+)
+
+public_key_der = private_key.public_key().public_bytes(
+    Encoding.DER,
+    PublicFormat.SubjectPublicKeyInfo
+)
+```
+
+### Capability Handling
+
+Kerbside uses hardcoded default capabilities based on observed behavior:
+- Common caps: 11 (AuthSelection, AuthSpice, MiniHeader)
+- Channel caps: 9 (SemiSeamlessMigrate, SeamlessMigrate)
+
+These values are sent in the server hello before the actual hypervisor
+capabilities are known.
+
+## Related Documentation
+
+- [Protocol Overview](protocol-overview.md) - High-level protocol introduction
+- [Channel Protocols](channel-protocols.md) - Per-channel message formats

--- a/docs/usb-redirection.md
+++ b/docs/usb-redirection.md
@@ -1,0 +1,613 @@
+# USB Redirection Protocol
+
+This document describes the USB redirection protocol used within SPICE's port
+channel. USB redirection allows USB devices connected to the client machine to
+be redirected to the virtual machine.
+
+## Overview
+
+USB redirection in SPICE uses the VMC (Virtual Machine Communication) protocol
+as a transport layer. The USB-specific protocol is called "usbredir" and is
+encapsulated within VMC data messages on the port channel (channel type 9).
+
+## Protocol References
+
+- [USB Redirection Protocol Spec](https://www.spice-space.org/usbredir.html)
+- [usbredir Source Code](https://gitlab.freedesktop.org/spice/usbredir)
+- [Protocol Header](https://gitlab.freedesktop.org/spice/usbredir/-/blob/main/usbredirparser/usbredirproto.h)
+- [Protocol Documentation](https://gitlab.freedesktop.org/spice/usbredir/-/blob/main/docs/usb-redirection-protocol.md)
+
+## USB Redir Packet Header
+
+USB redirection uses its own packet header format within the VMC encapsulation.
+The protocol supports two header formats depending on negotiated capabilities.
+
+### Standard Header (32-bit IDs)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  type (message type)
+4       4     uint32  length (payload length)
+8       4     uint32  id (sequence/correlation ID)
+```
+
+### Extended Header (64-bit IDs)
+
+When both sides advertise `usb_redir_cap_64bits_ids`:
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  type (message type)
+4       4     uint32  length (payload length)
+8       8     uint64  id (sequence/correlation ID)
+```
+
+All integers use little-endian byte order. Structures are packed without padding.
+
+## VMC Encapsulation
+
+USB redirection messages are wrapped in VMC data packets:
+
+```
+-- SPICE Port Channel Header (6 bytes) --
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       2     uint16  message_type (101 = vmc_data)
+2       4     uint32  message_size
+
+-- VMC Header (12 bytes) --
+6       4     uint32  vmc_type (usb_redir message type)
+10      4     uint32  vmc_length (usb_redir payload length)
+14      4     uint32  vmc_id (sequence/correlation ID)
+
+-- USB Redir Payload --
+18      var   bytes   usb_redir message data
+```
+
+## USB Redirection Message Types
+
+### Control Messages
+
+| ID | Message                        | Description |
+|---:|--------------------------------|-------------|
+|  0 | usb_redir_hello                | Protocol version exchange |
+|  1 | usb_redir_device_connect       | Device connection notification |
+|  2 | usb_redir_device_disconnect    | Device disconnection notification |
+|  3 | usb_redir_reset                | Reset USB device |
+|  4 | usb_redir_interface_info       | Interface descriptor info |
+|  5 | usb_redir_ep_info              | Endpoint descriptor info |
+|  6 | usb_redir_set_configuration    | Set USB configuration |
+|  7 | usb_redir_get_configuration    | Get current configuration |
+|  8 | usb_redir_configuration_status | Configuration status response |
+|  9 | usb_redir_set_alt_setting      | Set alternate interface setting |
+| 10 | usb_redir_get_alt_setting      | Get current alternate setting |
+| 11 | usb_redir_alt_setting_status   | Alternate setting status response |
+| 12 | usb_redir_start_iso_stream     | Start isochronous stream |
+| 13 | usb_redir_stop_iso_stream      | Stop isochronous stream |
+| 14 | usb_redir_iso_stream_status    | Isochronous stream status |
+| 15 | usb_redir_start_interrupt_receiving | Start interrupt endpoint |
+| 16 | usb_redir_stop_interrupt_receiving  | Stop interrupt endpoint |
+| 17 | usb_redir_interrupt_receiving_status | Interrupt status |
+| 18 | usb_redir_alloc_bulk_streams   | Allocate bulk streams |
+| 19 | usb_redir_free_bulk_streams    | Free bulk streams |
+| 20 | usb_redir_bulk_streams_status  | Bulk streams status |
+| 21 | usb_redir_cancel_data_packet   | Cancel pending data packet |
+| 22 | usb_redir_filter_reject        | Filter rejection notification |
+| 23 | usb_redir_filter_filter        | Device filter rules |
+| 24 | usb_redir_device_disconnect_ack | Acknowledge disconnection |
+| 25 | usb_redir_start_bulk_receiving | Start bulk endpoint receiving |
+| 26 | usb_redir_stop_bulk_receiving  | Stop bulk endpoint receiving |
+| 27 | usb_redir_bulk_receiving_status | Bulk receiving status |
+
+### Data Messages
+
+| ID  | Message                        | Description |
+|----:|--------------------------------|-------------|
+| 100 | usb_redir_control_packet       | Control transfer data |
+| 101 | usb_redir_bulk_packet          | Bulk transfer data |
+| 102 | usb_redir_iso_packet           | Isochronous transfer data |
+| 103 | usb_redir_interrupt_packet     | Interrupt transfer data |
+| 104 | usb_redir_buffered_bulk_packet | Buffered bulk transfer |
+
+## Message Formats
+
+### usb_redir_hello (ID 0)
+
+The first message exchanged between client and server to establish protocol
+version and capabilities.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       64    string  version (null-terminated, padded)
+64      4     uint32  capabilities (bitmask)
+```
+
+The version string identifies the usbredir implementation and version (e.g.,
+"qemu usb-redir guest 0.8.0").
+
+### usb_redir_device_connect (ID 1)
+
+Sent when a USB device is connected and available for redirection.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   speed (USB speed class)
+1       1     uint8   device_class
+2       1     uint8   device_subclass
+3       1     uint8   device_protocol
+4       2     uint16  vendor_id
+6       2     uint16  product_id
+8       2     uint16  device_version_bcd
+```
+
+USB Speed values:
+| Value | Speed |
+|------:|-------|
+| 0     | Unknown |
+| 1     | Low (1.5 Mbps) |
+| 2     | Full (12 Mbps) |
+| 3     | High (480 Mbps) |
+| 4     | Super (5 Gbps) |
+| 5     | Super+ (10 Gbps) |
+
+### usb_redir_device_disconnect (ID 2)
+
+Sent when a redirected USB device is disconnected. This message has no payload.
+
+### usb_redir_reset (ID 3)
+
+Request to reset the USB device. This message has no payload.
+
+### usb_redir_interface_info (ID 4)
+
+Provides information about all interfaces on the device.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       32    uint8[] interface_count per alt setting
+32      32    uint8[] interface_class
+64      32    uint8[] interface_subclass
+96      32    uint8[] interface_protocol
+```
+
+### usb_redir_ep_info (ID 5)
+
+Provides information about all endpoints on the device.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       32    uint8[] ep_type (per endpoint)
+32      32    uint8[] ep_interval
+64      32    uint8[] ep_interface
+96      64    uint16[] ep_max_packet_size
+```
+
+Endpoint types:
+| Value | Type |
+|------:|------|
+| 0     | Control |
+| 1     | Isochronous |
+| 2     | Bulk |
+| 3     | Interrupt |
+| 255   | Invalid |
+
+### usb_redir_set_configuration (ID 6)
+
+Request to set a specific USB configuration.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   configuration
+```
+
+### usb_redir_get_configuration (ID 7)
+
+Request the current USB configuration. This message has no payload.
+
+### usb_redir_configuration_status (ID 8)
+
+Response to set/get configuration requests.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   status
+1       1     uint8   configuration
+```
+
+### usb_redir_set_alt_setting (ID 9)
+
+Request to set an alternate interface setting.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   interface
+1       1     uint8   alt_setting
+```
+
+### usb_redir_get_alt_setting (ID 10)
+
+Request the current alternate setting for an interface.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   interface
+```
+
+### usb_redir_alt_setting_status (ID 11)
+
+Response to set/get alternate setting requests.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   status
+1       1     uint8   interface
+2       1     uint8   alt_setting
+```
+
+## Data Transfer Messages
+
+### usb_redir_control_packet (ID 100)
+
+USB control transfer (used for device configuration and standard requests).
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+1       1     uint8   request
+2       1     uint8   request_type
+3       1     uint8   status
+4       2     uint16  value
+6       2     uint16  index
+8       2     uint16  length
+10      var   bytes   data (if length > 0)
+```
+
+### usb_redir_bulk_packet (ID 101)
+
+USB bulk transfer (used for large data transfers).
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+1       1     uint8   status
+2       2     uint16  length
+4       4     uint32  stream_id
+8       2     uint16  length_high (extended length)
+10      var   bytes   data (if length > 0)
+```
+
+### usb_redir_iso_packet (ID 102)
+
+USB isochronous transfer (used for streaming data like audio/video).
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+1       1     uint8   status
+2       2     uint16  length
+4       var   bytes   data
+```
+
+### usb_redir_interrupt_packet (ID 103)
+
+USB interrupt transfer (used for periodic small data transfers).
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+1       1     uint8   status
+2       2     uint16  length
+4       var   bytes   data
+```
+
+## Status Codes
+
+USB redirection operations return status codes:
+
+| Value | Status |
+|------:|--------|
+| 0     | Success |
+| 1     | Cancelled |
+| 2     | INVAL (invalid parameter) |
+| 3     | IOERROR |
+| 4     | STALL |
+| 5     | TIMEOUT |
+| 6     | BABBLE |
+
+## Capabilities
+
+The hello message includes a capabilities bitmask indicating supported features:
+
+| Bit | Capability                    | Description |
+|----:|-------------------------------|-------------|
+| 0   | bulk_streams                  | USB 3.0 bulk streams support |
+| 1   | connect_device_version        | Device version BCD in connect packet |
+| 2   | filter                        | Filter reject/filter packets supported |
+| 3   | device_disconnect_ack         | Disconnect acknowledgment required |
+| 4   | ep_info_max_packet_size       | Max packet size in endpoint info |
+| 5   | 64bits_ids                    | 64-bit packet IDs |
+| 6   | 32bits_bulk_length            | 32-bit bulk packet length |
+| 7   | bulk_receiving                | Buffered bulk input support |
+
+## Additional Control Messages
+
+### usb_redir_start_iso_stream (ID 12)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+1       1     uint8   pkts_per_urb
+2       1     uint8   no_urbs
+```
+
+### usb_redir_stop_iso_stream (ID 13)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+```
+
+### usb_redir_iso_stream_status (ID 14)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   status
+1       1     uint8   endpoint
+```
+
+### usb_redir_start_interrupt_receiving (ID 15)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+```
+
+### usb_redir_stop_interrupt_receiving (ID 16)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   endpoint
+```
+
+### usb_redir_interrupt_receiving_status (ID 17)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   status
+1       1     uint8   endpoint
+```
+
+### usb_redir_alloc_bulk_streams (ID 18)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  endpoints (bitmask: bit N = endpoint N)
+4       4     uint32  no_streams
+```
+
+### usb_redir_free_bulk_streams (ID 19)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  endpoints (bitmask)
+```
+
+### usb_redir_bulk_streams_status (ID 20)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  endpoints (bitmask)
+4       4     uint32  no_streams
+8       1     uint8   status
+```
+
+### usb_redir_start_bulk_receiving (ID 25)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       4     uint32  bytes_per_transfer
+8       1     uint8   endpoint
+9       1     uint8   no_transfers
+```
+
+### usb_redir_stop_bulk_receiving (ID 26)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       1     uint8   endpoint
+```
+
+### usb_redir_bulk_receiving_status (ID 27)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       1     uint8   endpoint
+5       1     uint8   status
+```
+
+### usb_redir_filter_filter (ID 23)
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       N     string  filter rules (null-terminated)
+```
+
+Filter format: Rules separated by `|`, each rule is:
+`<class>,<vendor>,<product>,<version>,<allow>`
+
+- Use `-1` as wildcard for any value
+- Values can be decimal or `0x`-prefixed hex
+- `<allow>` is 0 (deny) or 1 (allow)
+
+Example: `-1,-1,-1,-1,1` allows all devices
+
+### usb_redir_buffered_bulk_packet (ID 104)
+
+For buffered bulk input (requires `bulk_receiving` capability):
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  stream_id
+4       4     uint32  length
+8       1     uint8   endpoint
+9       1     uint8   status
+10      var   bytes   data
+```
+
+## Protocol Rules
+
+### Message Direction
+
+- **Guest initiates**: Control packets and outbound data packets
+- **Host responds**: Same message type with matching ID
+- **Unsolicited from host**: `device_connect`, `device_disconnect`,
+  `filter_reject`, input data streams
+
+### Initialization Sequence
+
+The host must send messages in this order before `device_connect`:
+1. `ep_info` - Endpoint information
+2. `interface_info` - Interface descriptors
+3. `device_connect` - Device availability
+
+### Configuration Changes
+
+After successful `set_configuration` or `set_alt_setting`, the host must send:
+1. `ep_info` - Updated endpoint information
+2. `interface_info` - Updated interface descriptors
+3. `configuration_status` or `alt_setting_status` - Status response
+
+### Endpoint Numbering
+
+Endpoints are numbered 0-31:
+- Endpoints 0-15: OUT direction (host to device)
+- Endpoints 16-31: IN direction (device to host)
+- Endpoint 0 and 16: Control endpoint (always present)
+
+### Stream ID Management
+
+For isochronous and buffered bulk streams:
+- IDs start at 0 and increment per packet
+- IDs reset after stall condition recovery
+- Host resets ID on `_start_*` messages
+
+## Connection Flow
+
+A typical USB redirection session follows this flow:
+
+```
+    Client                                     Server (VM)
+      |                                            |
+      |  usb_redir_hello (version + caps)          |
+      |------------------------------------------->|
+      |                                            |
+      |  usb_redir_hello (version + caps)          |
+      |<-------------------------------------------|
+      |                                            |
+      |  usb_redir_device_connect                  |
+      |------------------------------------------->|
+      |                                            |
+      |  usb_redir_interface_info                  |
+      |------------------------------------------->|
+      |                                            |
+      |  usb_redir_ep_info                         |
+      |------------------------------------------->|
+      |                                            |
+      |  usb_redir_set_configuration               |
+      |<-------------------------------------------|
+      |                                            |
+      |  usb_redir_configuration_status            |
+      |------------------------------------------->|
+      |                                            |
+      |  [ Data transfers: bulk, interrupt, etc ]  |
+      |<------------------------------------------>|
+      |                                            |
+      |  usb_redir_device_disconnect               |
+      |------------------------------------------->|
+      |                                            |
+      |  usb_redir_device_disconnect_ack           |
+      |<-------------------------------------------|
+```
+
+## Kerbside Implementation
+
+Kerbside's USB redirection handling is implemented in
+`spiceprotocol/packets/port.py`. The proxy:
+
+1. Parses VMC headers to identify USB redirection messages
+2. Decodes the `usb_redir_hello` message to log version information
+3. Forwards all USB redirection traffic transparently between client and server
+4. Supports traffic inspection/logging when configured
+
+### Decoded Messages
+
+Kerbside currently decodes:
+- `usb_redir_hello` - Logs version string and capabilities
+
+All other USB redirection messages are forwarded without detailed parsing but
+can be logged in raw form for debugging.
+
+### Traffic Inspection
+
+When traffic inspection is enabled, USB redirection traffic can be logged:
+
+```python
+# Example inspection output
+Client sent 80 byte opcode 101 vmc_data
+   ... VMC type usb_redir_hello, length 68, id 0
+   ... version: qemu usb-redir guest 0.8.0
+   ... capabilities: 127
+```
+
+## Security Considerations
+
+USB redirection presents security considerations:
+
+1. **Device Access**: Redirected USB devices have direct access to the VM,
+   potentially exposing sensitive data.
+
+2. **Malicious Devices**: USB devices can potentially be used for attacks
+   (e.g., BadUSB).
+
+3. **Data Exposure**: USB traffic may contain sensitive data that should be
+   protected.
+
+Kerbside's audit logging records USB redirection channel establishment for
+security monitoring purposes.
+
+## Related Documentation
+
+- [Protocol Overview](protocol-overview.md) - High-level protocol introduction
+- [Channel Protocols](channel-protocols.md) - Per-channel message formats

--- a/docs/vd-agent-protocol.md
+++ b/docs/vd-agent-protocol.md
@@ -1,0 +1,376 @@
+# VD Agent Protocol
+
+This document describes the SPICE VD (Virtual Desktop) Agent protocol, which
+enables advanced guest integration features such as clipboard sharing, file
+transfer, and display configuration.
+
+## Overview
+
+The VD Agent is a guest-side component that communicates with the SPICE client
+through the main channel's agent messages. It provides:
+
+- Clipboard sharing between host and guest
+- File transfer (drag-and-drop)
+- Display/monitor configuration
+- Mouse mode synchronization
+- Audio volume synchronization
+
+**Note**: Kerbside proxies agent traffic transparently without decoding. This
+documentation is provided for reference and debugging purposes.
+
+## Transport
+
+Agent messages are carried over the main channel using:
+- Server to client: `AGENT_DATA` (ID 109), `AGENT_TOKEN` (ID 110)
+- Client to server: `AGENT_START` (ID 106), `AGENT_DATA` (ID 107), `AGENT_TOKEN` (ID 108)
+
+## Agent Message Header
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  protocol (protocol identifier)
+4       4     uint32  type (message type)
+8       8     uint64  opaque (implementation-specific)
+16      4     uint32  size (payload size)
+20      var   bytes   data (payload)
+```
+
+Maximum data size: 2048 bytes per message (larger data is chunked)
+
+## Message Types
+
+| ID | Message                      | Direction | Description |
+|---:|------------------------------|-----------|-------------|
+|  1 | MOUSE_STATE                  | S->A      | Mouse position and button state |
+|  2 | MONITORS_CONFIG              | C->A      | Display/monitor configuration |
+|  3 | REPLY                        | A->*      | Agent acknowledgment |
+|  4 | CLIPBOARD                    | Both      | Clipboard data transfer |
+|  5 | DISPLAY_CONFIG               | C->A      | Display settings |
+|  6 | ANNOUNCE_CAPABILITIES        | Both      | Feature capability declaration |
+|  7 | CLIPBOARD_GRAB               | Both      | Clipboard ownership claim |
+|  8 | CLIPBOARD_REQUEST            | Both      | Request clipboard data |
+|  9 | CLIPBOARD_RELEASE            | Both      | Release clipboard ownership |
+| 10 | FILE_XFER_START              | C->A      | Initiate file transfer |
+| 11 | FILE_XFER_STATUS             | A->C      | File transfer status |
+| 12 | FILE_XFER_DATA               | C->A      | File transfer data chunk |
+| 13 | CLIENT_DISCONNECTED          | S->A      | Client disconnection notification |
+| 14 | MAX_CLIPBOARD                | Both      | Maximum clipboard size |
+| 15 | AUDIO_VOLUME_SYNC            | Both      | Audio volume synchronization |
+| 16 | GRAPHICS_DEVICE_INFO         | C->A      | Device/monitor mapping |
+
+Direction key: S=Server, C=Client, A=Agent, Both=Bidirectional
+
+## Clipboard Protocol
+
+### Clipboard Formats
+
+| ID | Format     | Description |
+|---:|------------|-------------|
+|  1 | UTF8_TEXT  | UTF-8 encoded text |
+|  2 | IMAGE_PNG  | PNG image data |
+|  3 | IMAGE_BMP  | BMP image data |
+|  4 | IMAGE_TIFF | TIFF image data |
+|  5 | IMAGE_JPG  | JPEG image data |
+|  6 | FILE_LIST  | WebDAV file paths |
+
+### CLIPBOARD_GRAB (ID 7)
+
+Announces clipboard ownership and available formats.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4*N   uint32  format_types (array of available formats)
+```
+
+### CLIPBOARD_REQUEST (ID 8)
+
+Requests clipboard data in a specific format.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  type (requested format)
+```
+
+### CLIPBOARD (ID 4)
+
+Transfers clipboard data.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  type (data format)
+4       var   bytes   data
+```
+
+### CLIPBOARD_RELEASE (ID 9)
+
+Releases clipboard ownership. No payload.
+
+## Monitor Configuration
+
+### MONITORS_CONFIG (ID 2)
+
+Configures virtual display monitors.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  num_monitors
+4       4     uint32  flags
+8       N*28  struct  monitors (VDAgentMonConfig array)
+```
+
+Monitor configuration flags:
+| Bit | Flag | Description |
+|----:|------|-------------|
+| 0 | USE_POS | Use X/Y position fields |
+| 1 | PHYSICAL_SIZE | Include physical size (mm) |
+
+VDAgentMonConfig structure:
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  height
+4       4     uint32  width
+8       4     uint32  depth
+12      4     int32   x (position)
+16      4     int32   y (position)
+```
+
+## Mouse State
+
+### MOUSE_STATE (ID 1)
+
+Reports mouse position and button state.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  x
+4       4     uint32  y
+8       4     uint32  buttons (button mask)
+12      1     uint8   display_id
+```
+
+Agent button masks (note: different bit positions from inputs channel):
+
+| Bit | Mask | Button |
+|----:|-----:|--------|
+| 1 | 0x02 | Left |
+| 2 | 0x04 | Middle |
+| 3 | 0x08 | Right |
+| 4 | 0x10 | Wheel Up |
+| 5 | 0x20 | Wheel Down |
+| 6 | 0x40 | Side |
+| 7 | 0x80 | Extra |
+
+## File Transfer
+
+### FILE_XFER_START (ID 10)
+
+Initiates a file transfer.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  id (transfer ID)
+4       var   bytes   metadata (key-value pairs, null-terminated)
+```
+
+Metadata format: `key1:value1\nkey2:value2\n`
+Common keys: `name`, `size`
+
+### FILE_XFER_DATA (ID 12)
+
+Transfers file data chunk.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  id (transfer ID)
+4       8     uint64  size (chunk size)
+12      var   bytes   data
+```
+
+### FILE_XFER_STATUS (ID 11)
+
+Reports file transfer status.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  id (transfer ID)
+4       4     uint32  result
+8       var   bytes   data (optional error details)
+```
+
+Result values:
+| Value | Result | Description |
+|------:|--------|-------------|
+| 0 | CAN_SEND_DATA | Ready to receive more data |
+| 1 | CANCELLED | Transfer cancelled by user |
+| 2 | ERROR | Generic error |
+| 3 | SUCCESS | Transfer completed successfully |
+| 4 | NOT_ENOUGH_SPACE | Insufficient disk space |
+| 5 | SESSION_LOCKED | Guest session is locked |
+| 6 | VDAGENT_NOT_CONNECTED | Agent not connected |
+| 7 | DISABLED | File transfer disabled |
+
+## Capabilities
+
+### ANNOUNCE_CAPABILITIES (ID 6)
+
+Declares supported features.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  request (1 = request response)
+4       4*N   uint32  capabilities (bitmask array)
+```
+
+Capability bits:
+| Bit | Capability |
+|----:|------------|
+|  0  | MOUSE_STATE |
+|  1  | MONITORS_CONFIG |
+|  2  | REPLY |
+|  3  | CLIPBOARD |
+|  4  | DISPLAY_CONFIG |
+|  5  | CLIPBOARD_BY_DEMAND |
+|  6  | CLIPBOARD_SELECTION |
+|  7  | SPARSE_MONITORS_CONFIG |
+|  8  | GUEST_LINEEND_LF |
+|  9  | GUEST_LINEEND_CRLF |
+| 10  | MAX_CLIPBOARD |
+| 11  | AUDIO_VOLUME_SYNC |
+| 12  | MONITORS_CONFIG_POSITION |
+| 13  | FILE_XFER_DISABLED |
+| 14  | FILE_XFER_DETAILED_ERRORS |
+| 15  | GRAPHICS_DEVICE_INFO |
+| 16  | CLIPBOARD_NO_RELEASE_ON_REGRAB |
+| 17  | CLIPBOARD_GRAB_SERIAL |
+
+## Audio Volume Sync
+
+### AUDIO_VOLUME_SYNC (ID 15)
+
+Synchronizes audio volume settings.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       1     uint8   is_playback (1=playback, 0=record)
+1       1     uint8   mute
+2       1     uint8   nchannels
+3       2*N   uint16  volume (per channel, 0-65535)
+```
+
+## Graphics Device Info
+
+### GRAPHICS_DEVICE_INFO (ID 16)
+
+Maps SPICE display channels to physical graphics devices.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  count
+4       N*..  struct  device_display_info array
+```
+
+VDAgentDeviceDisplayInfo structure:
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  channel_id
+4       4     uint32  monitor_id
+8       4     uint32  device_address_len
+12      var   bytes   device_address (null-terminated)
+16+     4     uint32  device_display_id
+```
+
+## Reply Message
+
+### REPLY (ID 3)
+
+Generic acknowledgment.
+
+```
+Offset  Size  Type    Field
+------  ----  ------  -----------
+0       4     uint32  type (message being acknowledged)
+4       4     uint32  error (0=success)
+```
+
+## Protocol Flow
+
+### Initialization
+
+```
+    Client                Agent               Server
+      |                     |                    |
+      |  ANNOUNCE_CAPABILITIES (request=1)       |
+      |-------------------->|                    |
+      |                     |                    |
+      |  ANNOUNCE_CAPABILITIES (request=0)       |
+      |<--------------------|                    |
+      |                     |                    |
+      |  MONITORS_CONFIG                         |
+      |-------------------->|                    |
+```
+
+### Clipboard Copy (Client to Guest)
+
+```
+    Client                Agent
+      |                     |
+      |  CLIPBOARD_GRAB     |
+      |-------------------->|
+      |                     |
+      |  CLIPBOARD_REQUEST  |
+      |<--------------------|
+      |                     |
+      |  CLIPBOARD (data)   |
+      |-------------------->|
+```
+
+### File Transfer
+
+```
+    Client                Agent
+      |                     |
+      |  FILE_XFER_START    |
+      |-------------------->|
+      |                     |
+      |  FILE_XFER_DATA     |
+      |-------------------->|
+      |  FILE_XFER_DATA     |
+      |-------------------->|
+      |  ...                |
+      |                     |
+      |  FILE_XFER_STATUS   |
+      |<--------------------|
+```
+
+## Security Considerations
+
+1. **Clipboard Access**: Agent clipboard sharing allows data transfer between
+   host and guest, which may expose sensitive information.
+
+2. **File Transfer**: File transfer capabilities allow uploading files to the
+   guest VM, which could be used to transfer malware.
+
+3. **Display Configuration**: Monitor configuration changes could potentially
+   be used for social engineering attacks.
+
+Kerbside's audit logging records main channel establishment, which includes
+agent communication.
+
+## Related Documentation
+
+- [Protocol Overview](protocol-overview.md) - High-level SPICE protocol
+- [Channel Protocols](channel-protocols.md) - Main channel message details

--- a/kerbside/spiceprotocol/packets/constants.py
+++ b/kerbside/spiceprotocol/packets/constants.py
@@ -2,6 +2,8 @@ import copy
 
 
 # Map channel types back and forth
+# These values are defined in the SPICE protocol specification:
+# https://www.spice-space.org/spice-protocol.html
 channel_str_to_num = {
     'main': 1,
     'display': 2,
@@ -10,9 +12,10 @@ channel_str_to_num = {
     'playback': 5,
     'record': 6,
     'tunnel (obsolete)': 7,
-    'usbredir': 8,
-    'port': 9,
-    'webdav': 10
+    'smartcard': 8,
+    'usbredir': 9,
+    'port': 10,
+    'webdav': 11
 }
 
 
@@ -24,9 +27,10 @@ channel_num_to_str = {
     5: 'playback',
     6: 'record',
     7: 'tunnel (obsolete)',
-    8: 'usbredir',
-    9: 'port',
-    10: 'webdav'
+    8: 'smartcard',
+    9: 'usbredir',
+    10: 'port',
+    11: 'webdav'
 }
 
 


### PR DESCRIPTION
This commit adds extensive documentation for the SPICE protocol and Kerbside's implementation:

New documentation files:
- docs/index.md - Documentation index with version info
- docs/protocol-overview.md - SPICE protocol fundamentals
- docs/spice-link-protocol.md - Connection handshake details
- docs/channel-protocols.md - Per-channel message formats
- docs/capabilities.md - Capability negotiation reference
- docs/scancodes.md - Keyboard scancode reference
- docs/compression-protocols.md - LZ/GLZ compression formats
- docs/usb-redirection.md - USB device redirection protocol
- docs/vd-agent-protocol.md - Guest agent protocol
- docs/proxy-architecture.md - Internal proxy design
- docs/configuration.md - Configuration reference
- docs/console-sources.md - Source configuration guide
- docs/schema.md - Database schema with ASCII ER diagram

Bug fix:
- Fixed channel numbering in constants.py (smartcard=8, usbredir=9, port=10, webdav=11)

Other improvements:
- Updated README.md, ARCHITECTURE.md, AGENTS.md with doc links
- Consolidated error codes to single authoritative location
- Added cross-references between related documents
- Added verification notes for configuration and protocol docs

Prompt: Generate protocol docs and architectural documentation for Kerbside, verify against implementation, and address documentation review concerns.


Assisted-By: Claude Code