### PR TITLE
Use shared deploy-kolla-ansible action.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -399,60 +399,20 @@ jobs:
       - name: Build container images
         run: |
           . $GITHUB_ENV
-
-          script="cd /srv/shakenfist/kerbside-patches;"
-          script="${script} ./_build/build-containers.sh --build-targets ${{ matrix.test.openstack_release }} --build-images all --distro debian --image-tag local;"
-
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 "${script}"
-
-      - name: Bootstrap Kolla-Ansible
-        run: |
-          . $GITHUB_ENV
-          script="cd /srv/shakenfist/kerbside-patches;"
-          script="${script} sudo ./tools/bootstrap-kolla-ansible"
-              script="${script} --image-tag local"
-              script="${script} --build-targets ${{ matrix.test.openstack_release }}"
-              script="${script} --topology all-in-one;"
-
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 "${script}"
-
-      - name: Run pre-checks
-        run: |
-          . $GITHUB_ENV
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/ka prechecks -i /etc/kolla/inventory'
+              'cd /srv/shakenfist/kerbside-patches; ./_build/build-containers.sh --build-targets ${{ matrix.test.openstack_release }} --build-images all --distro debian --distro-version trixie --image-tag local'
 
-      - name: Deploy
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/ka deploy -i /etc/kolla/inventory'
+      - name: Deploy Kolla-Ansible
+        uses: shakenfist/actions/deploy-kolla-ansible@main
+        with:
+          base_user: ${{ matrix.test.baseuser }}
+          image_tag: local
+          build_targets: ${{ matrix.test.openstack_release }}
+          topology: all-in-one
 
-      - name: Install patched OpenStack clients
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/install-openstack-clients'
-
-      - name: Post install Kolla-Ansible setup
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/postinstall-kolla-ansible'
-
-      - name: Attempt to start an instance with a console and connect to it
+      - name: Test SPICE console connectivity
         run: |
           . $GITHUB_ENV
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -433,7 +433,7 @@ jobs:
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/test-console'
+              'cd /srv/shakenfist/kerbside-patches; sudo bash -c ". /etc/kolla/admin-openrc.sh && ./tools/test-console"'
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -396,6 +396,20 @@ jobs:
               ${{ matrix.test.baseuser }}@10.0.2.2 \
               'cd /srv/shakenfist/kerbside-patches; ./_build/assemble-source.sh --no-tarball ${{ matrix.test.openstack_release }}'
 
+      - name: Bootstrap Kolla-Ansible
+        run: |
+          . $GITHUB_ENV
+
+          script="cd /srv/shakenfist/kerbside-patches;"
+          script="${script} sudo ./tools/bootstrap-kolla-ansible"
+          script="${script} --image-tag ${{ matrix.test.openstack_release }}-debian-trixie-local"
+          script="${script} --build-targets ${{ matrix.test.openstack_release }}"
+          script="${script} --topology all-in-one;"
+
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              ${{ matrix.test.baseuser }}@10.0.2.2 "${script}"
+
       - name: Build container images
         run: |
           . $GITHUB_ENV
@@ -411,6 +425,7 @@ jobs:
           image_tag: ${{ matrix.test.openstack_release }}-debian-trixie-local
           build_targets: ${{ matrix.test.openstack_release }}
           topology: all-in-one
+          skip_bootstrap: 'true'
 
       - name: Test SPICE console connectivity
         run: |

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -394,7 +394,7 @@ jobs:
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; ./_build/assemble-source.sh ${{ matrix.test.openstack_release }}'
+              'cd /srv/shakenfist/kerbside-patches; ./_build/assemble-source.sh --no-tarball ${{ matrix.test.openstack_release }}'
 
       - name: Build container images
         run: |

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -408,7 +408,7 @@ jobs:
         uses: shakenfist/actions/deploy-kolla-ansible@main
         with:
           base_user: ${{ matrix.test.baseuser }}
-          image_tag: local
+          image_tag: ${{ matrix.test.openstack_release }}-debian-trixie-local
           build_targets: ${{ matrix.test.openstack_release }}
           topology: all-in-one
 


### PR DESCRIPTION
Replace inlined Kolla-Ansible deploy steps with the new shakenfist/actions/deploy-kolla-ansible composite action. This fixes the CI build which had diverged from kerbside-patches (missing bootstrap flags caused empty passwords at prechecks). Also adds
--distro-version trixie to the build-containers call to match current kerbside-patches defaults.

Prompt: Fix the kerbside CI Kolla-Ansible build by sharing deploy steps via a composite action in the shakenfist/actions repo.