### PR TITLE
Fix indirect-dependencies CI for pyproject.toml.

### DIFF
--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   indirect-dependencies:
-    runs-on: [self-hosted, vm]
+    runs-on: [self-hosted, vm, debian-12]
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -61,7 +61,9 @@ jobs:
 
           cd ${GITHUB_WORKSPACE}/kerbside
           python3 -m venv  --system-site-packages ${RUNNER_TEMP}/venv
-          ${RUNNER_TEMP}/venv/bin/pip install -r requirements.txt
+          . ${RUNNER_TEMP}/venv/bin/activate
+          pip3 install uv
+          uv pip install -r pyproject.toml
 
       - name: List all our dependencies
         run: |
@@ -79,8 +81,8 @@ jobs:
           for depver in $(${RUNNER_TEMP}/venv/bin/pip freeze --local); do
             dep=$(echo ${depver} | sed 's/==.*//')
 
-            if [ $(egrep -ic "^${dep}==" requirements.txt) -lt 1 ]; then
-              echo "${depver}" >> requirements.txt
+            if [ $(egrep -ic "${dep}==" pyproject.toml) -lt 1 ]; then
+              sed -i pyproject.toml "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/"
             fi
           done
 
@@ -95,6 +97,11 @@ jobs:
             git commit -a -m "Update pinned dependencies."
             git push -f origin pin-dependencies-${datestamp}
             echo
+            # Ensure the label exists before creating the PR
+            gh label create dependencies --color 0075ca \
+                --description "Pull requests that update a dependency file" \
+                2>/dev/null || true
+
             gh pr create \
                 --assignee mikalstill \
                 --reviewer mikalstill \

--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -82,7 +82,7 @@ jobs:
             dep=$(echo ${depver} | sed 's/==.*//')
 
             if [ $(egrep -ic "${dep}==" pyproject.toml) -lt 1 ]; then
-              sed -i pyproject.toml "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/"
+              sed -i "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/" pyproject.toml
             fi
           done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,20 @@ ps aux | grep kerbside
 5. **Database Connections**: SQLAlchemy sessions should be properly closed.
    Use context managers or explicit `session.close()`.
 
+## Dependency Management
+
+### Indirect Dependency Pinning
+
+Dependencies are declared in `pyproject.toml`. Indirect (transitive) dependencies
+are pinned in the same file, in a section ending with a `# END_OF_INDIRECT_DEPS`
+marker comment. A daily CI job (`pin-indirect-dependencies.yml`) detects new
+unpinned indirect dependencies and creates PRs to pin them. The marker comment
+must not be removed, as the CI job uses `sed` to insert new entries before it.
+
+When adding a new direct dependency to `pyproject.toml`, place it in the main
+dependencies list above the "Indirect dependencies" comment. Do not place it
+after the `# END_OF_INDIRECT_DEPS` marker.
+
 ## External Dependencies
 
 ### Required Python Packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "pytz==2025.2",
     "werkzeug==3.1.3",
     "zipp==3.21.0",
+    # END_OF_INDIRECT_DEPS
 ]
 
 [project.urls]


### PR DESCRIPTION
Update pin-indirect-dependencies.yml to install from pyproject.toml instead of the removed requirements.txt. Use uv for installation and sed with END_OF_INDIRECT_DEPS marker to inject new dependencies into pyproject.toml.

Prompt: The indirect-dependencies CI job did not survive the conversion to pyproject.toml from requirements.txt. Could you please update this specific job, but also determine which other repositories in shakenfist/ are affected?