### PR TITLE
tools: optional RPM mirror in ovirt-gather-artifacts.

### DIFF
--- a/tools/ovirt-gather-artifacts.sh
+++ b/tools/ovirt-gather-artifacts.sh
@@ -4,6 +4,15 @@
 # This script runs on the oVirt target node. It collects RPM lists,
 # download URLs, engine logs, VDSM logs, and SSH config into a zip
 # bundle at /tmp/bundle.zip for upload as a CI artifact.
+#
+# Environment variables:
+#   MIRROR_RPMS=1   Also download every RPM listed in /tmp/rpms.urls
+#                   into /tmp/rpms.cache/ and bundle the files. Off by
+#                   default; turning this on bloats the bundle from
+#                   tens of MB to 1-2 GB on a typical oVirt install, so
+#                   it is unsuitable for CI artifact storage but useful
+#                   when reproducing ancient releases whose upstream
+#                   mirrors may disappear.
 
 set -xe
 export PS4='=======================\n+ '
@@ -18,6 +27,16 @@ for rpm in $(cat /tmp/rpms.list); do
         >> /tmp/rpms.urls 2>/dev/null || true
 done
 
+# Optional RPM mirroring: fetch every URL into a local cache directory
+# so the result is a self-contained, replayable install set.
+extra_zip_paths=()
+if [ "${MIRROR_RPMS:-0}" = "1" ]; then
+    sudo dnf -y install wget
+    sudo mkdir -p /tmp/rpms.cache
+    sudo wget -nv -P /tmp/rpms.cache -i /tmp/rpms.urls || true
+    extra_zip_paths+=("/tmp/rpms.cache")
+fi
+
 sudo zip -r /tmp/bundle.zip \
     /etc/yum.repos.d \
     /tmp/rpms.list \
@@ -26,6 +45,7 @@ sudo zip -r /tmp/bundle.zip \
     /var/log/ovirt-engine/ \
     /var/log/vdsm/ \
     /etc/ssh/sshd_config.d/ \
+    "${extra_zip_paths[@]}" \
     || true
 sudo chmod ugo+r /tmp/bundle.zip
 ls -lrth /tmp/bundle.zip


### PR DESCRIPTION
Adds a MIRROR_RPMS=1 env-var gated step that downloads every RPM URL collected in /tmp/rpms.urls into /tmp/rpms.cache/ and includes the cache in the artifact zip. Off by default so CI artifact size is unaffected.

The motivation is homelab reproductions of ancient releases (e.g. oVirt 4.3 on CentOS 7) where the upstream mirrors that the yumdownloader URLs point at may disappear over time. A URL list is useless once the mirrors go away; an actual RPM cache lets the install be replayed forever.

Typical impact when enabled: bundle grows from ~tens of MB to ~1-2 GB on a single-node oVirt engine install, so this is deliberately not the CI default.

Prompt: Mikal remembered there was code "to build a mirror of all of the RPMs used" but found only the URL collector. Asked to extend the existing script with a toggle, defaulted off so CI is unaffected.


Assisted-By: Claude Opus 4.7 (1M context, medium effort)