### PR TITLE
ovirt-gather-artifacts: honor MIRROR_RPMS=1.

### DIFF
--- a/tools/ovirt-gather-artifacts.sh
+++ b/tools/ovirt-gather-artifacts.sh
@@ -8,15 +8,34 @@
 set -xe
 export PS4='=======================\n+ '
 
+# MIRROR_RPMS=1 also downloads each resolved RPM into /tmp/rpm-mirror so
+# the bundle contains a self-contained package cache, not just URLs.
+MIRROR_RPMS="${MIRROR_RPMS:-0}"
+
 sudo rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
     | grep -v '^gpg-pubkey' > /tmp/rpms.list
+
+if [ "${MIRROR_RPMS}" = "1" ]; then
+    sudo rm -rf /tmp/rpm-mirror
+    sudo mkdir -p /tmp/rpm-mirror
+fi
 
 for rpm in $(cat /tmp/rpms.list); do
     echo "Caching URLs for ${rpm}"
     sudo yumdownloader --resolve --urls "${rpm}" \
         | egrep -v '(metadata expiration|Waiting for)' \
         >> /tmp/rpms.urls 2>/dev/null || true
+    if [ "${MIRROR_RPMS}" = "1" ]; then
+        echo "Downloading ${rpm} into mirror"
+        sudo yumdownloader --resolve --destdir=/tmp/rpm-mirror "${rpm}" \
+            >/dev/null 2>&1 || true
+    fi
 done
+
+bundle_extra=()
+if [ "${MIRROR_RPMS}" = "1" ]; then
+    bundle_extra+=(/tmp/rpm-mirror)
+fi
 
 sudo zip -r /tmp/bundle.zip \
     /etc/yum.repos.d \
@@ -26,6 +45,7 @@ sudo zip -r /tmp/bundle.zip \
     /var/log/ovirt-engine/ \
     /var/log/vdsm/ \
     /etc/ssh/sshd_config.d/ \
+    "${bundle_extra[@]}" \
     || true
 sudo chmod ugo+r /tmp/bundle.zip
 ls -lrth /tmp/bundle.zip


### PR DESCRIPTION
The MIRROR_RPMS env var was already plumbed in from the homelab ovirt_engine role but the script ignored it -- it only ever wrote rpms.list and rpms.urls, never the RPMs themselves. When set to "1", also yumdownloader --resolve each RPM into /tmp/rpm-mirror and include that directory in bundle.zip, so the artifact is a self-contained package cache instead of just a manifest.

Default stays MIRROR_RPMS=0, matching prior behavior for callers that didn't opt in (kerbside CI itself).

Prompt: Mikal noticed that the homelab oVirt build's mirror directory contained only rpms.list / rpms.urls and no actual RPMs, despite the homelab role being wired up yesterday to request a mirror via MIRROR_RPMS=1. The gather script was never updated to read that env var, so wire the flag the whole way through.


Assisted-By: Claude Opus 4.7 (1M context, low effort)