### PR TITLE
Install the sf collection before building infrastructure.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -186,7 +186,7 @@ jobs:
               ${GITHUB_WORKSPACE}/shakenfist
 
           ansible-playbook -i /home/debian/ansible-hosts \
-              --extra-vars "identifier=${SHAKENFIST_NAMESPACE} base=${{ matrix.test.base }} environment_name=${{ matrix.test.environment_name }} hostname=${{ matrix.test.hostname }}" \
+              --extra-vars "identifier=${SHAKENFIST_NAMESPACE} base=${{ matrix.test.base }} base_user=${{ matrix.test.baseuser }} environment_name=${{ matrix.test.environment_name }} hostname=${{ matrix.test.hostname }}" \
               --tags all ${GITHUB_WORKSPACE}/actions/ansible/kerbside-single-node.yml
 
       - name: Prepare /srv on target

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -165,10 +165,26 @@ jobs:
           path: kerbside
           fetch-depth: 0
 
+      # The under-cloud playbooks create their test instances with the
+      # shakenfist.shakenfist collection's native sf_* modules (the client's
+      # ansible shims they previously used were retired), so the collection
+      # must be resolvable on this runner. It is built from a shakenfist
+      # repository checkout.
+      - name: Checkout the shakenfist repository
+        uses: actions/checkout@v4
+        with:
+          repository: shakenfist/shakenfist
+          path: shakenfist
+          fetch-depth: 1
+
       - name: Build infrastructure
         shell: bash
         run: |
           . $GITHUB_ENV
+
+          ${GITHUB_WORKSPACE}/actions/tools/install-collection.sh \
+              ${GITHUB_WORKSPACE}/shakenfist
+
           ansible-playbook -i /home/debian/ansible-hosts \
               --extra-vars "identifier=${SHAKENFIST_NAMESPACE} base=${{ matrix.test.base }} environment_name=${{ matrix.test.environment_name }} hostname=${{ matrix.test.hostname }}" \
               --tags all ${GITHUB_WORKSPACE}/actions/ansible/kerbside-single-node.yml


### PR DESCRIPTION
The under-cloud playbooks in the actions repository now create their test instances with the shakenfist.shakenfist collection's native sf_* modules -- the shakenfist-client ansible shims they previously resolved against were retired. Check out the shakenfist repository and install the collection (via the actions repo's tools/install-collection.sh) before the direct kerbside-single-node.yml invocation. The other test jobs use the setup-kerbside-environment composite action, which gained the same treatment in the actions repository.

Prompt: The client-python shim retirement broke under-cloud provisioning for kerbside CI; install the collection before the playbooks run.


Assisted-By: Claude Opus 4.8 (200K context, high effort)