### PR TITLE
Install the SF collection in the oVirt CI job.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -165,6 +165,24 @@ jobs:
           path: kerbside
           fetch-depth: 0
 
+      # The under-cloud playbook creates its test instance with the
+      # shakenfist.shakenfist collection's native sf_* modules (the
+      # client's ansible shims they previously used were retired), so
+      # the collection must be resolvable on this runner. It is built
+      # from a shakenfist repository checkout.
+      - name: Checkout the shakenfist repository
+        uses: actions/checkout@v4
+        with:
+          repository: shakenfist/shakenfist
+          path: shakenfist
+          fetch-depth: 1
+
+      - name: Install the shakenfist.shakenfist collection
+        shell: bash
+        run: |
+          ${GITHUB_WORKSPACE}/actions/tools/install-collection.sh \
+              ${GITHUB_WORKSPACE}/shakenfist
+
       - name: Build infrastructure
         shell: bash
         run: |


### PR DESCRIPTION
The ovirt_matrix job in functional-tests.yml runs the kerbside-single-node.yml playbook from shakenfist/actions directly, rather than via the setup-kerbside-environment composite action. That playbook now creates its test instance with the
shakenfist.shakenfist collection's native sf_* modules (the client-python ansible shims it previously resolved were retired), so the job failed with "couldn't resolve module/action 'shakenfist.shakenfist.sf_namespace'". Check out the shakenfist repository and run tools/install-collection.sh before building infrastructure, mirroring the composite action.

Prompt: Mikal reported that the shim-removal work had also broken Kerbside oVirt CI testing and pointed at the failing run. This adds the missing collection install to the one kerbside job that invokes the actions playbooks directly.


Assisted-By: Claude Code